### PR TITLE
Support ending sessions with Ctrl-D

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -3,7 +3,7 @@
 
 name: lint and test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   ruff-black-isort:

--- a/mentat/app.py
+++ b/mentat/app.py
@@ -33,7 +33,7 @@ def run(paths: Iterable[str]):
     cost_tracker = CostTracker()
     try:
         loop(paths, cost_tracker)
-    except KeyboardInterrupt as e:
+    except (EOFError, KeyboardInterrupt) as e:
         print(e)
     finally:
         cost_tracker.display_total_cost()


### PR DESCRIPTION
Mentat currently supports using Ctrl-C or 'q' to end a session:

<img width="725" alt="Screenshot 2023-07-26 at 5 17 22 PM" src="https://github.com/biobootloader/mentat/assets/134455/4047b4c5-f406-4f35-a35e-3f716dba9ce5">


However, these ol' fingers are long habituated to using Ctrl-D to end interactive sessions. This PR adds support for `EOFError` to end a session.