### PR TITLE
Fix rel_path vs abs_path typo

### DIFF
--- a/mentat/code_file_manager.py
+++ b/mentat/code_file_manager.py
@@ -309,7 +309,7 @@ class CodeFileManager:
         rel_path = changes[0].file
         abs_path = os.path.join(self.git_root, rel_path)
         new_code_lines = self.file_lines[abs_path].copy()
-        if new_code_lines != self._read_file(rel_path):
+        if new_code_lines != self._read_file(abs_path):
             logging.info(f"File '{rel_path}' changed while generating changes")
             cprint(
                 (


### PR DESCRIPTION
code_file_manager _read_file() expects to receive an absolute path but was accidentally being handed a relative path immediately after the absolute path was computed. 

This caused mentat to be unable to apply changes to files if mentat was launched with a path other than "."