### PR TITLE
Improve handling of large projects

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,25 +22,11 @@ Determines which file types inside of a directory will be automatically included
 }
 ```
 
-### Filepath Include and Exclude list
-Optional lists of regex patterns that determin which files or directories will be included 
-or excluded from context. Either or both lists can be provided. If the file path matches 
-both an inclusion rule and an exclusion rule, the exclusion rule always wins (including 
-for example filetype exclusion wins over filepath inclusion).
+### File Exclude Glob list
+List of [glob patterns](https://docs.python.org/3/library/glob.html) that will exclude all files from context that it matches starting from the given directory.
 ```
 {
-    "filepath-include-only-these-regex-patterns": [".*/include_this"],
-    "filepath-exclude-these-regex-patterns": [".*/exclude_this"]
-}
-```
-
-### Disable .gitignore processing
-There is currently an issue where large projects can overwhelm the test for .gitignore exclusion. This option
-disables .gitignore testing to support working with those larger projects. Default is false, which
-allows mentat to make use of git ignore testing.
-```
-{
-    "do-not-check-git-ignored": true,
+    "file-exclude-glob-list": ["**/exclude_this.*"]
 }
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,28 @@ Determines which file types inside of a directory will be automatically included
 }
 ```
 
+### Filepath Include and Exclude list
+Optional lists of regex patterns that determin which files or directories will be included 
+or excluded from context. Either or both lists can be provided. If the file path matches 
+both an inclusion rule and an exclusion rule, the exclusion rule always wins (including 
+for example filetype exclusion wins over filepath inclusion).
+```
+{
+    "filepath-include-only-these-regex-patterns": [".*/include_this"],
+    "filepath-exclude-these-regex-patterns": [".*/exclude_this"]
+}
+```
+
+### Disable .gitignore processing
+There is currently an issue where large projects can overwhelm the test for .gitignore exclusion. This option
+disables .gitignore testing to support working with those larger projects. Default is false, which
+allows mentat to make use of git ignore testing.
+```
+{
+    "do-not-check-git-ignored": true,
+}
+```
+
 ### Input Style
 A list of key-value pairs defining a custom [Pygment Style](https://pygments.org/docs/styledevelopment/) to style the Mentat prompt.
 ```

--- a/mentat/code_file_manager.py
+++ b/mentat/code_file_manager.py
@@ -216,7 +216,10 @@ class CodeFileManager:
                 path_set.add(os.path.realpath(path))
             elif path.is_dir():
                 non_git_ignored_files = set(
-                    filter(
+                    # git returns / seperated paths even on windows, convert so we can remove
+                    # glob_excluded_files, which have windows paths on windows
+                    os.path.normpath(path)
+                    for path in filter(
                         lambda p: p != "",
                         subprocess.check_output(
                             # -c shows cached (regular) files, -o shows other (untracked/ new) files
@@ -236,8 +239,6 @@ class CodeFileManager:
                         recursive=True,
                     )
                 )
-                if glob_excluded_files:
-                    assert False, (non_git_ignored_files, glob_excluded_files)
                 nonignored_files = non_git_ignored_files - glob_excluded_files
 
                 non_text_files = filter(

--- a/mentat/code_file_manager.py
+++ b/mentat/code_file_manager.py
@@ -1,8 +1,8 @@
+import glob
 import logging
 import math
 import mimetypes
 import os
-import re
 import subprocess
 from collections import defaultdict
 from pathlib import Path
@@ -178,8 +178,9 @@ class CodeFileManager:
         for file_type in config.filetype_exclude_list():
             mimetypes.types_map.pop(file_type, None)
 
+        self.config = config
         self.git_root = _get_shared_git_root_for_paths(paths)
-        self._set_file_paths(config, paths)
+        self._set_file_paths(paths)
         self.user_input_manager = user_input_manager
 
         if self.file_paths:
@@ -195,7 +196,7 @@ class CodeFileManager:
             self.git_root,
         )
 
-    def _set_file_paths(self, config: ConfigManager, paths: Iterable[str] = None) -> None:
+    def _set_file_paths(self, paths: Iterable[str] = None) -> None:
         invalid_paths = []
         for path in paths:
             if not os.path.exists(path):
@@ -211,31 +212,32 @@ class CodeFileManager:
         self.non_text_file_paths = []
         self.file_paths = []
 
-        def _any_regex(path, patterns, value_if_empty):
-            if not patterns:
-                return value_if_empty
-            return any(bool(re.match(pattern, path)) for pattern in patterns)
-
         for path in paths:
             path = Path(path)
             if path.is_file():
                 path_set.add(os.path.realpath(path))
             elif path.is_dir():
                 all_files = set(pathspec.util.iter_tree_files(path, follow_links=False))
-                if config.do_not_check_git_ignore():
-                    ignored_by_git = []
-                else:
-                    repo = git.Repo(self.git_root)
-                    ignored_by_git = repo.ignored(*all_files)
-                    repo.close()
-                git_folder_files = list(filter(lambda p: p.startswith(".git"), all_files))
-                files_with_optionally_excluded_paths = list(filter(lambda p: _any_regex(p, config.filepath_exclude_these_regex_patterns(), False), all_files))
-                files_lacking_optionally_included_paths = list(filter(lambda p: not _any_regex(p, config.filepath_include_only_these_regex_patterns(), True), all_files))
+
+                repo = git.Repo(self.git_root)
+                ignored_by_git = repo.ignored(*all_files)
+                repo.close()
+                git_folder_files = list(
+                    filter(lambda p: p.startswith(".git"), all_files)
+                )
+                glob_excluded_files = list(
+                    file
+                    for glob_path in self.config.file_exclude_glob_list()
+                    # If the user puts a / at the beginning, it will try to look in root directory
+                    for file in glob.glob(
+                        pathname=glob_path.lstrip("/"),
+                        root_dir=path,
+                        recursive=True,
+                    )
+                )
+
                 ignore_files = set(
-                    ignored_by_git
-                    + git_folder_files
-                    + files_with_optionally_excluded_paths
-                    + files_lacking_optionally_included_paths
+                    ignored_by_git + git_folder_files + glob_excluded_files
                 )
                 nonignored_files = all_files - ignore_files
                 non_text_files = filter(

--- a/mentat/code_file_manager.py
+++ b/mentat/code_file_manager.py
@@ -236,6 +236,8 @@ class CodeFileManager:
                         recursive=True,
                     )
                 )
+                if glob_excluded_files:
+                    assert False, (non_git_ignored_files, glob_excluded_files)
                 nonignored_files = non_git_ignored_files - glob_excluded_files
 
                 non_text_files = filter(

--- a/mentat/config_manager.py
+++ b/mentat/config_manager.py
@@ -37,11 +37,20 @@ class ConfigManager:
     def filetype_exclude_list(self) -> list[str]:
         return self._get_key("filetype-exclude-list")
 
-    def _get_key(self, key: str):
+    def filepath_include_only_these_regex_patterns(self) -> list[str]:
+        return self._get_key("filepath-include-only-these-regex-patterns", False)
+    
+    def filepath_exclude_these_regex_patterns(self) -> list[str]:
+        return self._get_key("filepath-exclude-these-regex-patterns", False)
+
+    def do_not_check_git_ignore(self) -> bool:
+        return self._get_key("do-not-check-git-ignore", False)
+
+    def _get_key(self, key: str, is_required = True):
         if key in self.user_config:
             return self.user_config[key]
         elif key in self.default_config:
             return self.default_config[key]
-        else:
+        elif is_required:
             logging.error(f"No value for config key {key} found")
-            return None
+        return None

--- a/mentat/config_manager.py
+++ b/mentat/config_manager.py
@@ -37,20 +37,14 @@ class ConfigManager:
     def filetype_exclude_list(self) -> list[str]:
         return self._get_key("filetype-exclude-list")
 
-    def filepath_include_only_these_regex_patterns(self) -> list[str]:
-        return self._get_key("filepath-include-only-these-regex-patterns", False)
-    
-    def filepath_exclude_these_regex_patterns(self) -> list[str]:
-        return self._get_key("filepath-exclude-these-regex-patterns", False)
+    def file_exclude_glob_list(self) -> list[str]:
+        return self._get_key("file-exclude-glob-list")
 
-    def do_not_check_git_ignore(self) -> bool:
-        return self._get_key("do-not-check-git-ignore", False)
-
-    def _get_key(self, key: str, is_required = True):
+    def _get_key(self, key: str):
         if key in self.user_config:
             return self.user_config[key]
         elif key in self.default_config:
             return self.default_config[key]
-        elif is_required:
-            logging.error(f"No value for config key {key} found")
-        return None
+        else:
+            logging.warning(f"No value for config key {key} found")
+            return None

--- a/mentat/default_config.json
+++ b/mentat/default_config.json
@@ -15,5 +15,6 @@
         ]
     ],
     "filetype-include-list": [],
-    "filetype-exclude-list": []
+    "filetype-exclude-list": [],
+    "file-exclude-glob-list": []
 }

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read_requirements(file):
 
 setup(
     name="mentat-ai",
-    version="0.1.3",
+    version="0.1.4",
     python_requires=">=3.10",
     packages=find_packages(),
     install_requires=read_requirements("requirements.txt"),

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -82,7 +82,7 @@ def test_glob_exclude(mocker, temp_testbed):
     # Makes sure glob exclude config works
     mock_glob_exclude = mocker.MagicMock()
     mocker.patch.object(ConfigManager, "file_exclude_glob_list", new=mock_glob_exclude)
-    mock_glob_exclude.side_effect = [["glob_test/**/*.py"]]
+    mock_glob_exclude.side_effect = [[os.path.join("glob_test", "**", "*.py")]]
 
     glob_exclude_path = os.path.join("glob_test", "bagel", "apple", "exclude_me.py")
     glob_include_path = os.path.join("glob_test", "bagel", "apple", "include_me.ts")
@@ -93,7 +93,7 @@ def test_glob_exclude(mocker, temp_testbed):
     with open(glob_include_path, "w") as glob_include_file:
         glob_include_file.write("I am included")
 
-    code_file_manager = CodeFileManager(["./"], user_input_manager=None, config=config)
+    code_file_manager = CodeFileManager(["."], user_input_manager=None, config=config)
     print(code_file_manager.file_paths)
     assert (
         os.path.join(temp_testbed, glob_exclude_path)

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -40,12 +40,14 @@ def test_path_gitignoring(temp_testbed):
     case.assertCountEqual(expected_file_paths, code_file_manager.file_paths)
 
 
-def test_ignore_non_text_files():
+def test_ignore_non_text_files(temp_testbed):
     image_file_path = "image.jpg"
     with open(image_file_path, "w") as image_file:
         image_file.write("I am an image")
     code_file_manager = CodeFileManager(["./"], user_input_manager=None, config=config)
-    assert image_file_path not in code_file_manager.file_paths
+    assert (
+        os.path.join(temp_testbed, image_file_path) not in code_file_manager.file_paths
+    )
 
 
 def test_no_paths_given(temp_testbed):
@@ -72,3 +74,27 @@ def test_two_git_roots_given():
             ["./", "git_testing_dir"], user_input_manager=None, config=config
         )
     assert e_info.type == SystemExit
+
+
+def test_glob_exclude(mocker, temp_testbed):
+    # Makes sure glob exclude config works
+    mock_glob_exclude = mocker.MagicMock()
+    mocker.patch.object(ConfigManager, "file_exclude_glob_list", new=mock_glob_exclude)
+    mock_glob_exclude.side_effect = [["glob_test/**/*.py"]]
+
+    glob_exclude_path = "glob_test/bagel/apple/exclude_me.py"
+    glob_include_path = "glob_test/bagel/apple/include_me.ts"
+    os.makedirs(os.path.dirname(glob_exclude_path), exist_ok=True)
+    with open(glob_exclude_path, "w") as glob_exclude_file:
+        glob_exclude_file.write("I am excluded")
+    os.makedirs(os.path.dirname(glob_include_path), exist_ok=True)
+    with open(glob_include_path, "w") as glob_include_file:
+        glob_include_file.write("I am included")
+
+    code_file_manager = CodeFileManager(["./"], user_input_manager=None, config=config)
+    print(code_file_manager.file_paths)
+    assert (
+        os.path.join(temp_testbed, glob_exclude_path)
+        not in code_file_manager.file_paths
+    )
+    assert os.path.join(temp_testbed, glob_include_path) in code_file_manager.file_paths

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -82,8 +82,8 @@ def test_glob_exclude(mocker, temp_testbed):
     mocker.patch.object(ConfigManager, "file_exclude_glob_list", new=mock_glob_exclude)
     mock_glob_exclude.side_effect = [["glob_test/**/*.py"]]
 
-    glob_exclude_path = "glob_test/bagel/apple/exclude_me.py"
-    glob_include_path = "glob_test/bagel/apple/include_me.ts"
+    glob_exclude_path = os.path.join("glob_test", "bagel", "apple", "exclude_me.py")
+    glob_include_path = os.path.join("glob_test", "bagel", "apple", "include_me.ts")
     os.makedirs(os.path.dirname(glob_exclude_path), exist_ok=True)
     with open(glob_exclude_path, "w") as glob_exclude_file:
         glob_exclude_file.write("I am excluded")


### PR DESCRIPTION
Summary:

Adds several optional configuration properties to improve handling of large projects to work around limits in the number of tokens that can be handled by GPT-4 and limits in the number of files that can be passed to the git `repo.ignored()` function.

From the modified `docs/configuration.md`:

### Filepath Include and Exclude list
Optional lists of regex patterns that determine which files or directories will be included 
or excluded from context. Either or both lists can be provided. If the file path matches 
both an inclusion rule and an exclusion rule, the exclusion rule always wins (including 
for example filetype exclusion wins over filepath inclusion).
```
{
    "filepath-include-only-these-regex-patterns": [".*/include_this"],
    "filepath-exclude-these-regex-patterns": [".*/exclude_this"]
}
```

### Disable .gitignore processing
There is currently an issue where large projects can overwhelm the test for .gitignore exclusion. This option
disables .gitignore testing to support working with those larger projects. Default is false, which
allows mentat to make use of git ignore testing.
```
{
    "do-not-check-git-ignored": true,
}
```