### PR TITLE
make required python version 3.10 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ See more videos on [Twitter](https://twitter.com/bio_bootloader/status/168390673
 Before installing, it's suggested that you create a virtual environment to install it in:
 
 ```
+# Python 3.10 or higher is required
 python3 -m venv .venv
 source .venv/bin/activate
 ```

--- a/mentat/app.py
+++ b/mentat/app.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+import sys
 from typing import Iterable
 
 from termcolor import cprint
@@ -25,6 +26,10 @@ def run_cli():
 
 
 def run(paths: Iterable[str]):
+    if sys.version_info < (3, 10):
+        print("Error: Python version 3.10 or higher is required.")
+        return
+
     os.makedirs(mentat_dir_path, exist_ok=True)
     setup_logging()
     setup_api_key()

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ def read_requirements(file):
 
 setup(
     name="mentat-ai",
+    python_requires=">=3.10",
     version="0.1.2",
     packages=find_packages(),
     install_requires=read_requirements("requirements.txt"),


### PR DESCRIPTION
Tested with pyenv, pip won't let you install packages if your python version is too low. There is no point in making a version check in mentat since it won't even run below 3.10 because of the match statements.