### PR TITLE
Fix bug filter gitignore sooner

### DIFF
--- a/mentat/code_file_manager.py
+++ b/mentat/code_file_manager.py
@@ -219,7 +219,10 @@ class CodeFileManager:
                     filter(
                         lambda p: p != "" and not p.startswith(".git"),
                         subprocess.check_output(
-                            ["git", "ls-files", "."], cwd=path, text=True
+                            # -c shows cached (regular) files, -o shows other (untracked/ new) files
+                            ["git", "ls-files", "-c", "-o"],
+                            cwd=path,
+                            text=True,
                         ).split("\n"),
                     )
                 )

--- a/mentat/code_file_manager.py
+++ b/mentat/code_file_manager.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Iterable
 
-import git
 from termcolor import cprint
 
 from .change_conflict_resolution import (
@@ -209,7 +208,6 @@ class CodeFileManager:
         self.non_text_file_paths = []
         self.file_paths = []
 
-        repo = git.Repo(self.git_root)
         for path in paths:
             path = Path(path)
             if path.is_file():
@@ -217,10 +215,10 @@ class CodeFileManager:
             elif path.is_dir():
                 nonignored_files = set(
                     filter(
-                        lambda p: p != "" and not p.startswith(".git"),
+                        lambda p: p != "",
                         subprocess.check_output(
                             # -c shows cached (regular) files, -o shows other (untracked/ new) files
-                            ["git", "ls-files", "-c", "-o"],
+                            ["git", "ls-files", "-c", "-o", "--exclude-standard"],
                             cwd=path,
                             text=True,
                         ).split("\n"),
@@ -246,7 +244,6 @@ class CodeFileManager:
                     ),
                 )
                 path_set.update(text_files)
-        repo.close()
         self.file_paths = list(path_set)
 
     def _read_file(self, abs_path) -> Iterable[str]:

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -12,9 +12,10 @@ config = ConfigManager()
 
 def test_path_gitignoring(temp_testbed):
     gitignore_path = ".gitignore"
-    os.makedirs("git_testing_dir")
-    ignored_path = "git_testing_dir/ignored_file.txt"
-    nonignored_path = "git_testing_dir/nonignored_file.txt"
+    testing_dir_path = "git_testing_dir"
+    os.makedirs(testing_dir_path)
+    ignored_path = os.path.join(testing_dir_path, "ignored_file.txt")
+    nonignored_path = os.path.join(testing_dir_path, "nonignored_file.txt")
     with open(gitignore_path, "a") as gitignore_file:
         gitignore_file.write("\nignored_file.txt\nnonignored_file.txt")
     with open(ignored_path, "w") as ignored_file:

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -12,8 +12,9 @@ config = ConfigManager()
 
 def test_path_gitignoring(temp_testbed):
     gitignore_path = ".gitignore"
-    ignored_path = "ignored_file.txt"
-    nonignored_path = "nonignored_file.txt"
+    os.makedirs("git_testing_dir")
+    ignored_path = "git_testing_dir/ignored_file.txt"
+    nonignored_path = "git_testing_dir/nonignored_file.txt"
     with open(gitignore_path, "a") as gitignore_file:
         gitignore_file.write("\nignored_file.txt\nnonignored_file.txt")
     with open(ignored_path, "w") as ignored_file:
@@ -21,14 +22,13 @@ def test_path_gitignoring(temp_testbed):
     with open(nonignored_path, "w") as nonignored_file:
         nonignored_file.write("I am not ignored")
 
-    os.makedirs("git_testing_dir")
     in_dir_path = os.path.join("git_testing_dir", "in_dir.txt")
     with open(in_dir_path, "w") as in_dir_file:
         in_dir_file.write("I am in a directory")
 
     # Gets all non-git-ignored files inside directory
     # Doesn't get git-ignored files unless specifically asked for
-    paths = ["git_testing_dir", "nonignored_file.txt"]
+    paths = ["git_testing_dir", "git_testing_dir/nonignored_file.txt"]
     code_file_manager = CodeFileManager(paths, user_input_manager=None, config=config)
 
     expected_file_paths = [


### PR DESCRIPTION
Fix the bug with too many files in large directories. This bug was caused because we traversed the entire file path tree without ignoring .gitignore files. Now we do those together.