### PR TITLE
Fix test bugs; Clean up tests

### DIFF
--- a/mentat/llm_api.py
+++ b/mentat/llm_api.py
@@ -57,6 +57,36 @@ def count_tokens(message: str) -> int:
     return len(tiktoken.encoding_for_model("gpt-4").encode(message))
 
 
+def check_model_availability(allow_32k: bool) -> bool:
+    available_models = [x["id"] for x in openai.Model.list()["data"]]
+    if allow_32k:
+        # check if user has access to gpt-4-32k
+        if "gpt-4-32k-0314" not in available_models:
+            cprint(
+                (
+                    "You set ALLOW_32K to true, but your OpenAI API key doesn't"
+                    " have access to gpt-4-32k-0314. To remove this warning, set"
+                    " ALLOW_32K to false until you have access."
+                ),
+                "yellow",
+            )
+            allow_32k = False
+
+    if not allow_32k:
+        # check if user has access to gpt-4
+        if "gpt-4-0314" not in available_models:
+            cprint(
+                (
+                    "Sorry, but your OpenAI API key doesn't have access to gpt-4-0314,"
+                    " which is currently required to run Mentat."
+                ),
+                "red",
+            )
+            raise KeyboardInterrupt
+
+    return allow_32k
+
+
 def choose_model(messages: list[dict[str, str]], allow_32k) -> str:
     prompt_token_count = 0
     tokenizer = tiktoken.encoding_for_model("gpt-4")

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -14,31 +14,32 @@ def test_path_gitignoring(temp_testbed):
     gitignore_path = ".gitignore"
     testing_dir_path = "git_testing_dir"
     os.makedirs(testing_dir_path)
-    ignored_path = os.path.join(testing_dir_path, "ignored_file.txt")
-    nonignored_path = os.path.join(testing_dir_path, "nonignored_file.txt")
-    with open(gitignore_path, "a") as gitignore_file:
-        gitignore_file.write("\nignored_file.txt\nnonignored_file.txt")
-    with open(ignored_path, "w") as ignored_file:
-        ignored_file.write("I am ignored")
-    with open(nonignored_path, "w") as nonignored_file:
-        nonignored_file.write("I am not ignored")
 
-    in_dir_path = os.path.join("git_testing_dir", "in_dir.txt")
-    with open(in_dir_path, "w") as in_dir_file:
-        in_dir_file.write("I am in a directory")
+    # create 3 files, 2 ignored in gitignore, 1 not
+    ignored_file_path_1 = os.path.join(testing_dir_path, "ignored_file_1.txt")
+    ignored_file_path_2 = os.path.join(testing_dir_path, "ignored_file_2.txt")
+    non_ignored_file_path = os.path.join(testing_dir_path, "non_ignored_file.txt")
 
-    # Gets all non-git-ignored files inside directory
-    # Doesn't get git-ignored files unless specifically asked for
-    paths = ["git_testing_dir", "git_testing_dir/nonignored_file.txt"]
+    with open(gitignore_path, "w") as gitignore_file:
+        gitignore_file.write("ignored_file_1.txt\nignored_file_2.txt")
+
+    for file_path in [ignored_file_path_1, ignored_file_path_2, non_ignored_file_path]:
+        with open(file_path, "w") as file:
+            file.write("I am a file")
+
+    # Run CodeFileManager on the git_testing_dir, and also explicitly pass in ignored_file_2.txt
+    paths = [testing_dir_path, ignored_file_path_2]
     code_file_manager = CodeFileManager(paths, user_input_manager=None, config=config)
 
     expected_file_paths = [
-        os.path.join(temp_testbed, nonignored_path),
-        os.path.join(temp_testbed, in_dir_path),
+        os.path.join(temp_testbed, ignored_file_path_2),
+        os.path.join(temp_testbed, non_ignored_file_path),
     ]
 
     case = TestCase()
-    case.assertCountEqual(expected_file_paths, code_file_manager.file_paths)
+    case.assertListEqual(
+        sorted(expected_file_paths), sorted(code_file_manager.file_paths)
+    )
 
 
 def test_ignore_non_text_files():

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,7 +1,7 @@
 from mentat.config_manager import ConfigManager
 
 
-def test_user_config(change_cwd):
+def test_user_config():
     config = ConfigManager()
 
-    assert not config.allow_32k()
+    assert config.allow_32k() is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,9 @@ def mock_collect_user_input(mocker):
 
 @pytest.fixture
 def mock_setup_api_key(mocker):
-    return mocker.patch("mentat.app.setup_api_key")
+    mocker.patch("mentat.app.setup_api_key")
+    mocker.patch("mentat.conversation.check_model_availability")
+    return
 
 
 def add_permissions(func, path, exc_info):
@@ -91,7 +93,7 @@ def add_permissions(func, path, exc_info):
 
 
 @pytest.fixture(autouse=True)
-def temp_testbed():
+def temp_testbed(monkeypatch):
     # create temporary copy of testbed, complete with git repo
     # realpath() resolves symlinks, required for paths to match on macOS
     temp_dir = os.path.realpath(tempfile.mkdtemp())
@@ -117,14 +119,12 @@ def temp_testbed():
         stderr=subprocess.DEVNULL,
     )
 
-    yield temp_testbed
+    # necessary to undo chdir before calling rmtree, or it fails on windows
+    with monkeypatch.context() as m:
+        m.chdir(temp_testbed)
+        yield temp_testbed
 
     shutil.rmtree(temp_dir, onerror=add_permissions)
-
-
-@pytest.fixture(autouse=True)
-def change_cwd(temp_testbed, monkeypatch):
-    monkeypatch.chdir(temp_testbed)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
- Move checking model availability from `Conversation.__init__` to new function in llm_api. Also it now checks for `gpt-4-0314` on startup and exits gracefully if it isn't available. This function is also mocked, which fixes a bug where tests would fail due to an attempted OpenAI call to get the model list when users had a config with `allow_32k=True`. 
- Clarify the check being made in `test_path_gitignoring`, and change assert to test paths are the same.
- Move `monkeypatch.chdir` fixture into `temp_testbed` to improve clarity.