### PR TITLE
Remove filetype checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ Run Mentat from within your project directory. Mentat uses git, so if your proje
 
 `mentat <paths to files or directories>`
 
-If you provide a directory, Mentat will add all non-hidden text files in that directory to it's context. If this exceeds the GPT-4 token context limit, try running Mentat with just the files you need it to see.
+If you provide a directory, Mentat will add all non git-ignored text files in that directory to it's context. If this exceeds the GPT-4 token context limit, try running Mentat with just the files you need it to see.

--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ Run Mentat from within your project directory. Mentat uses git, so if your proje
 
 `mentat <paths to files or directories>`
 
-If you provide a directory, Mentat will add all non git-ignored text files in that directory to it's context. If this exceeds the GPT-4 token context limit, try running Mentat with just the files you need it to see.
+If you provide a directory, Mentat will add all non git-ignored text files in that directory to it's context. If you provide a glob pattern, Mentat will add all files matching the pattern to it's context. If this exceeds the GPT-4 token context limit, try running Mentat with just the files you need it to see.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,10 +14,10 @@ Allow Mentat to use OpenAI's gpt-4 32k context window model. Your API key must a
 ```
 
 ### File Exclude Glob list
-List of [glob patterns](https://docs.python.org/3/library/glob.html) that will exclude all files from context that it matches starting from the given directory.
+List of [glob patterns](https://docs.python.org/3/library/glob.html) that will exclude all files from context that it matches starting from the given directory. Importantly, this means that the pattern to exclude all files ending with `.py` would be `**/*.py` rather than `*.py`. Here is an example that would exclude all hidden directories and files:
 ```
 {
-    "file-exclude-glob-list": ["**/exclude_this.*"]
+    "file-exclude-glob-list": ["**/.*, **/.*/**"]
 }
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ Allow Mentat to use OpenAI's gpt-4 32k context window model. Your API key must a
 ```
 
 ### File Exclude Glob list
-List of [glob patterns](https://docs.python.org/3/library/glob.html) that will exclude all files from context that it matches starting from the given directory. Importantly, this means that the pattern to exclude all files ending with `.py` would be `**/*.py` rather than `*.py`. Here is an example that would exclude all hidden directories and files:
+List of [glob patterns](https://docs.python.org/3/library/glob.html) that will exclude all files from context that it matches starting from the git root. Importantly, this means that the pattern to exclude all files ending with `.py` would be `**/*.py` rather than `*.py`. Here is an example that would exclude all hidden directories and files:
 ```
 {
     "file-exclude-glob-list": ["**/.*, **/.*/**"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,15 +13,6 @@ Allow Mentat to use OpenAI's gpt-4 32k context window model. Your API key must a
 }
 ```
 
-### Filetype Include and Exclude list
-Determines which file types inside of a directory will be automatically included or excluded from context when Mentat is given a directory. This will not affect hidden files, ignored files, or files specified by their direct path.
-```
-{
-    "filetype-include-list": [".include_this"],
-    "filetype-exclude-list": [".exclude_this"]
-}
-```
-
 ### File Exclude Glob list
 List of [glob patterns](https://docs.python.org/3/library/glob.html) that will exclude all files from context that it matches starting from the given directory.
 ```

--- a/mentat/app.py
+++ b/mentat/app.py
@@ -1,4 +1,5 @@
 import argparse
+import glob
 import logging
 import os
 from typing import Iterable
@@ -20,9 +21,20 @@ def run_cli():
     parser = argparse.ArgumentParser(
         description="Run conversation with command line args"
     )
-    parser.add_argument("paths", nargs="*", help="Paths to directories or files")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Space separated list of file paths, directory paths, or glob patterns",
+    )
     paths = parser.parse_args().paths
-    run(paths)
+    run(expand_paths(paths))
+
+
+def expand_paths(paths: Iterable[str]) -> Iterable[str]:
+    globbed_paths = set()
+    for path in paths:
+        globbed_paths.update(glob.glob(pathname=path, recursive=True))
+    return globbed_paths
 
 
 def run(paths: Iterable[str]):

--- a/mentat/code_file_manager.py
+++ b/mentat/code_file_manager.py
@@ -1,7 +1,6 @@
 import glob
 import logging
 import math
-import mimetypes
 import os
 from collections import defaultdict
 from pathlib import Path
@@ -22,41 +21,6 @@ from .git_handler import (
 )
 from .user_input_manager import UserInputManager
 
-# mimetypes is OS dependent, so it's best to add as many extensions as we can
-# fmt: off
-default_filetype_include_list = [
-    ".py",      # Python
-    ".java",    # Java
-    ".scala",   # Scala
-    ".kt",      # Kotlin
-    ".php",     # PHP
-    ".html",    # HTML
-    ".css",     # CSS
-    ".less",    # Less
-    ".scss",    # SCSS
-    ".js",      # Javascript
-    ".ts",      # Typescript
-    ".c",       # C
-    ".cpp",     # C++
-    ".h",       # C Header
-    ".cs",      # C#
-    ".go",      # Go
-    ".rs",      # Rust
-    ".rb",      # Ruby
-    ".swift",   # Swift
-    ".lua",     # Lua
-    ".pl",      # Perl
-    ".sql",     # SQL
-    ".r",       # R
-    ".m",       # objective-c
-    ".sh",      # shell scripts
-    ".f",       # fortran
-    ".jsx",     # javascript react
-    ".tsx",     # typescript react
-]
-default_filetype_exclude_list = []
-# fmt: on
-
 
 def _build_path_tree(file_paths, git_root):
     tree = {}
@@ -71,7 +35,7 @@ def _build_path_tree(file_paths, git_root):
     return tree
 
 
-def _print_path_tree(tree, non_text_files, changed_files, cur_path, prefix=""):
+def _print_path_tree(tree, changed_files, cur_path, prefix=""):
     keys = list(tree.keys())
     for i, key in enumerate(sorted(keys)):
         if i < len(keys) - 1:
@@ -85,15 +49,13 @@ def _print_path_tree(tree, non_text_files, changed_files, cur_path, prefix=""):
         star = "* " if cur in changed_files else ""
         if tree[key]:
             color = "blue"
-        elif cur in non_text_files:
-            color = "yellow"
         elif star:
             color = "green"
         else:
             color = None
         cprint(f"{star}{key}", color)
         if tree[key]:
-            _print_path_tree(tree[key], non_text_files, changed_files, cur, new_prefix)
+            _print_path_tree(tree[key], changed_files, cur, new_prefix)
 
 
 def _is_file_text_encoded(file_path):
@@ -106,16 +68,6 @@ def _is_file_text_encoded(file_path):
         return False
 
 
-def _is_file_code(file_path):
-    file_type, encoding = mimetypes.guess_type(file_path)
-    return (
-        file_type
-        and file_type.split("/")[0] == "text"
-        and encoding is None
-        and _is_file_text_encoded(file_path)
-    )
-
-
 class CodeFileManager:
     def __init__(
         self,
@@ -124,17 +76,6 @@ class CodeFileManager:
         config: ConfigManager,
         git_root: str,
     ):
-        # Make sure to apply user config last
-        for file_type in default_filetype_include_list:
-            mimetypes.add_type("text/default-include-list", file_type)
-        for file_type in default_filetype_exclude_list:
-            mimetypes.types_map.pop(file_type, None)
-
-        for file_type in config.filetype_include_list():
-            mimetypes.add_type("text/user-include-list", file_type)
-        for file_type in config.filetype_exclude_list():
-            mimetypes.types_map.pop(file_type, None)
-
         self.config = config
         self.git_root = git_root
         self._set_file_paths(paths)
@@ -147,8 +88,7 @@ class CodeFileManager:
             cprint("Git project: ", "green", end="")
         cprint(os.path.split(self.git_root)[1], "blue")
         _print_path_tree(
-            _build_path_tree(self.file_paths + self.non_code_file_paths, self.git_root),
-            self.non_code_file_paths,
+            _build_path_tree(self.file_paths, self.git_root),
             get_paths_with_git_diffs(self.git_root),
             self.git_root,
         )
@@ -165,7 +105,6 @@ class CodeFileManager:
             print("Exiting...")
             exit()
 
-        self.non_code_file_paths = set()
         self.file_paths = set()
 
         for path in paths:
@@ -198,19 +137,12 @@ class CodeFileManager:
                     )
                 )
 
-                self.non_code_file_paths.update(
-                    filter(
-                        lambda f: not _is_file_code(f),
-                        nonignored_files,
-                    )
-                )
                 self.file_paths.update(
                     filter(
-                        _is_file_code,
+                        _is_file_text_encoded,
                         nonignored_files,
                     )
                 )
-        self.non_code_file_paths = list(self.non_code_file_paths)
         self.file_paths = list(self.file_paths)
 
     def _read_file(self, abs_path) -> Iterable[str]:
@@ -236,12 +168,6 @@ class CodeFileManager:
             if git_diff_output:
                 code_message.append("Current git diff for this file:")
                 code_message.append(f"{git_diff_output}")
-        if self.non_code_file_paths:
-            code_message.append("\nOther files:\n")
-            code_message.extend(
-                os.path.relpath(path, self.git_root)
-                for path in self.non_code_file_paths
-            )
         return "\n".join(code_message)
 
     def _handle_delete(self, delete_change):

--- a/mentat/config_manager.py
+++ b/mentat/config_manager.py
@@ -61,12 +61,6 @@ class ConfigManager:
     def allow_32k(self) -> bool:
         return self._get_key("allow-32k")
 
-    def filetype_include_list(self) -> list[str]:
-        return self._get_key("filetype-include-list")
-
-    def filetype_exclude_list(self) -> list[str]:
-        return self._get_key("filetype-exclude-list")
-
     def file_exclude_glob_list(self) -> list[str]:
         return self._get_key("file-exclude-glob-list")
 

--- a/mentat/default_config.json
+++ b/mentat/default_config.json
@@ -14,7 +14,5 @@
             "#ffffff bold"
         ]
     ],
-    "filetype-include-list": [],
-    "filetype-exclude-list": [],
     "file-exclude-glob-list": []
 }

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -41,18 +41,6 @@ def test_path_gitignoring(temp_testbed, mock_config):
     )
 
 
-def test_ignore_non_text_files(temp_testbed, mock_config):
-    image_file_path = "image.jpg"
-    with open(image_file_path, "w") as image_file:
-        image_file.write("I am an image")
-    code_file_manager = CodeFileManager(
-        ["./"], user_input_manager=None, config=mock_config, git_root="./"
-    )
-    assert (
-        os.path.join(temp_testbed, image_file_path) not in code_file_manager.file_paths
-    )
-
-
 def test_glob_exclude(mocker, temp_testbed, mock_config):
     # Makes sure glob exclude config works
     mock_glob_exclude = mocker.MagicMock()
@@ -77,31 +65,6 @@ def test_glob_exclude(mocker, temp_testbed, mock_config):
         not in code_file_manager.file_paths
     )
     assert os.path.join(temp_testbed, glob_include_path) in code_file_manager.file_paths
-
-
-def test_code_file_checking(temp_testbed, mock_config):
-    # Makes sure non 'code' files aren't automatically picked up unless we request them
-    noncode_path = "iamnotcode.notcode"
-    noncode_path_requested = "iamalsonotcode.notcode"
-    with open(noncode_path, "w") as f:
-        f.write("I am an innocent non-code file!")
-    with open(noncode_path_requested, "w") as f:
-        f.write("I am an innocent non-code file that has been requested by the user!")
-
-    paths = ["./", noncode_path_requested]
-    code_file_manager = CodeFileManager(
-        paths, user_input_manager=None, config=mock_config, git_root="./"
-    )
-
-    assert (
-        os.path.join(temp_testbed, noncode_path_requested)
-        in code_file_manager.file_paths
-    )
-    assert os.path.join(temp_testbed, noncode_path) not in code_file_manager.file_paths
-    assert (
-        os.path.join(temp_testbed, noncode_path)
-        in code_file_manager.non_code_file_paths
-    )
 
 
 def test_text_encoding_checking(temp_testbed, mock_config):

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 import pytest
 
+from mentat.app import expand_paths
 from mentat.code_file_manager import CodeFileManager
 from mentat.config_manager import ConfigManager
 
@@ -27,7 +28,7 @@ def test_path_gitignoring(temp_testbed, mock_config):
     # Run CodeFileManager on the git_testing_dir, and also explicitly pass in ignored_file_2.txt
     paths = [testing_dir_path, ignored_file_path_2]
     code_file_manager = CodeFileManager(
-        paths, user_input_manager=None, config=mock_config, git_root="./"
+        paths, user_input_manager=None, config=mock_config, git_root=temp_testbed
     )
 
     expected_file_paths = [
@@ -57,14 +58,35 @@ def test_glob_exclude(mocker, temp_testbed, mock_config):
         glob_include_file.write("I am included")
 
     code_file_manager = CodeFileManager(
-        ["."], user_input_manager=None, config=mock_config, git_root="./"
+        ["."], user_input_manager=None, config=mock_config, git_root=temp_testbed
     )
-    print(code_file_manager.file_paths)
     assert (
         os.path.join(temp_testbed, glob_exclude_path)
         not in code_file_manager.file_paths
     )
     assert os.path.join(temp_testbed, glob_include_path) in code_file_manager.file_paths
+
+
+def test_glob_include(temp_testbed, mock_config):
+    # Make sure glob include works
+    glob_include_path = os.path.join("glob_test", "bagel", "apple", "include_me.py")
+    glob_include_path2 = os.path.join("glob_test", "bagel", "apple", "include_me2.py")
+    glob_exclude_path = os.path.join("glob_test", "bagel", "apple", "exclude_me.ts")
+
+    os.makedirs(os.path.dirname(glob_include_path), exist_ok=True)
+    with open(glob_include_path, "w") as glob_include_file:
+        glob_include_file.write("I am included")
+    os.makedirs(os.path.dirname(glob_include_path2), exist_ok=True)
+    with open(glob_include_path2, "w") as glob_include_file:
+        glob_include_file.write("I am also included")
+    os.makedirs(os.path.dirname(glob_exclude_path), exist_ok=True)
+    with open(glob_exclude_path, "w") as glob_exclude_file:
+        glob_exclude_file.write("I am excluded")
+
+    file_paths = expand_paths(["**/*.py"])
+    assert glob_exclude_path not in file_paths
+    assert glob_include_path in file_paths
+    assert glob_include_path2 in file_paths
 
 
 def test_text_encoding_checking(temp_testbed, mock_config):
@@ -76,7 +98,7 @@ def test_text_encoding_checking(temp_testbed, mock_config):
 
     paths = ["./"]
     code_file_manager = CodeFileManager(
-        paths, user_input_manager=None, config=mock_config, git_root="./"
+        paths, user_input_manager=None, config=mock_config, git_root=temp_testbed
     )
     assert os.path.join(temp_testbed, nontext_path) not in code_file_manager.file_paths
 
@@ -88,6 +110,6 @@ def test_text_encoding_checking(temp_testbed, mock_config):
 
         paths = [nontext_path_requested]
         _ = CodeFileManager(
-            paths, user_input_manager=None, config=mock_config, git_root="./"
+            paths, user_input_manager=None, config=mock_config, git_root=temp_testbed
         )
     assert e_info.type == KeyboardInterrupt


### PR DESCRIPTION
Remove filetype checking, add glob includes, and fix a few bugs. To test include globs in zsh, put quotes around paths.

In case you're wondering why the glob path expansion is at the very beginning (outside of codefilemanager), there are 2 reasons:
1. We need it to resolve the git root
2. Because some terminals (such as zsh) automatically expand glob patterns, I think it's best to do it at the very beginning so there is no difference between terminals.