### PR TITLE
Model error handling

### DIFF
--- a/mentat/code_change.py
+++ b/mentat/code_change.py
@@ -63,7 +63,7 @@ class CodeChange:
         except ValueError:
             raise ModelError(
                 f"Model created change with unknown action {self.json_data['action']}",
-                unfinished_change=False,
+                already_added_to_changelist=False,
             )
 
         try:
@@ -109,7 +109,10 @@ class CodeChange:
                 self.file_lines = code_file_manager.file_lines[file_path]
                 self.line_number_buffer = len(str(len(self.file_lines) + 1)) + 1
             except KeyError:
-                self.error = f"Model attempt to edit {file_path}, which isn't in current context or doesn't exist"
+                self.error = (
+                    f"Model attempted to edit {file_path}, which isn't in current"
+                    " context or doesn't exist"
+                )
         else:
             if os.path.exists(self.file):
                 self.error = (

--- a/mentat/code_change.py
+++ b/mentat/code_change.py
@@ -113,7 +113,7 @@ class CodeChange:
         else:
             if os.path.exists(self.file):
                 self.error = (
-                    f"Model attempted to create file {self.file} that already exists"
+                    f"Model attempted to create file that already exists: {self.file}"
                 )
 
             self.file_lines = []

--- a/mentat/code_change.py
+++ b/mentat/code_change.py
@@ -109,7 +109,7 @@ class CodeChange:
                 self.file_lines = code_file_manager.file_lines[file_path]
                 self.line_number_buffer = len(str(len(self.file_lines) + 1)) + 1
             except KeyError:
-                self.error = f"File {file_path} not included in context"
+                self.error = f"Model attempt to edit {file_path}, which isn't in current context or doesn't exist"
         else:
             if os.path.exists(self.file):
                 self.error = (

--- a/mentat/logging_config.py
+++ b/mentat/logging_config.py
@@ -13,7 +13,8 @@ def setup_logging():
     logs_path = os.path.join(mentat_dir_path, logs_dir)
 
     logging.getLogger("openai").setLevel(logging.WARNING)
-    logging.getLogger("asyncio").setLevel(logging.WARNING)
+    # Breaking out of async generator when model messes up causes an error
+    logging.getLogger("asyncio").setLevel(logging.CRITICAL)
     formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 
     console_handler = logging.StreamHandler()

--- a/mentat/model_error.py
+++ b/mentat/model_error.py
@@ -1,5 +1,5 @@
 # Raised when model output doesn't adhere to the specified format for changes
 class ModelError(Exception):
-    def __init__(self, message, unfinished_change):
+    def __init__(self, message, already_added_to_changelist):
         super().__init__(message)
-        self.unfinished_change = unfinished_change
+        self.already_added_to_changelist = already_added_to_changelist

--- a/mentat/model_error.py
+++ b/mentat/model_error.py
@@ -1,4 +1,4 @@
-# Raised when model messes up creating a change
+# Raised when model output doesn't adhere to the specified format for changes
 class ModelError(Exception):
     def __init__(self, message, unfinished_change):
         super().__init__(message)

--- a/mentat/model_error.py
+++ b/mentat/model_error.py
@@ -1,0 +1,5 @@
+# Raised when model messes up creating a change
+class ModelError(Exception):
+    def __init__(self, message, unfinished_change):
+        super().__init__(message)
+        self.unfinished_change = unfinished_change

--- a/mentat/parsing.py
+++ b/mentat/parsing.py
@@ -197,6 +197,7 @@ async def stream_and_parse_llm_response(
     except ModelError as e:
         logging.info(f"Model created error {e}")
         printer.wrap_it_up()
+        # make sure we finish printing everything model sent before we encountered the crash
         await printer_task
         cprint("\n\nFatal error while processing model response:", "red")
         cprint(e, color="red")

--- a/mentat/parsing.py
+++ b/mentat/parsing.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 from enum import Enum
+from json import JSONDecodeError
 from timeit import default_timer
 from typing import Generator
 
@@ -19,6 +20,7 @@ from .code_change_display import (
 )
 from .code_file_manager import CodeFileManager
 from .llm_api import call_llm_api
+from .model_error import ModelError
 from .streaming_printer import StreamingPrinter
 
 
@@ -66,10 +68,17 @@ class ParsingState:
         )
 
     def create_code_change(self, code_file_manager: CodeFileManager):
-        json_data = json.loads("\n".join(self.json_lines))
-        self.code_changes.append(
-            CodeChange(json_data, self.code_lines, self.git_root, code_file_manager)
+        try:
+            json_data = json.loads("\n".join(self.json_lines))
+        except JSONDecodeError:
+            raise ModelError(
+                "Model gave malformed JSON for change", unfinished_change=False
+            )
+
+        new_change = CodeChange(
+            json_data, self.code_lines, self.git_root, code_file_manager
         )
+        self.code_changes.append(new_change)
         self.json_lines, self.code_lines = [], []
 
     def new_line(self, code_file_manager: CodeFileManager):
@@ -79,16 +88,38 @@ class ParsingState:
         created_code_change = False
         match self.cur_line.rstrip("\n"):
             case _BlockIndicator.Start.value:
-                assert not self.in_special_lines and not self.in_code_lines
+                if self.in_special_lines or self.in_code_lines:
+                    raise ModelError(
+                        "Model gave start indicator while making change",
+                        unfinished_change=True,
+                    )
                 self.in_special_lines = True
             case _BlockIndicator.Code.value:
-                assert self.in_special_lines and not self.in_code_lines
+                if not self.in_special_lines or self.in_code_lines:
+                    raise ModelError(
+                        "Model gave code indicator while it was not making a change",
+                        unfinished_change=False,
+                    )
+                if self.in_code_lines:
+                    raise ModelError(
+                        "Model gave code indicator while in code block",
+                        unfinished_change=True,
+                    )
                 self.in_code_lines = True
                 self.create_code_change(code_file_manager)
+                if not self.code_changes[-1].action.has_additions():
+                    raise ModelError(
+                        "Model gave code indicator for action without code",
+                        unfinished_change=True,
+                    )
                 entered_code_lines = True
                 created_code_change = True
             case _BlockIndicator.End.value:
-                assert self.in_special_lines
+                if not self.in_special_lines:
+                    raise ModelError(
+                        "Model gave end indicator while not creating change",
+                        unfinished_change=False,
+                    )
                 if not self.in_code_lines:
                     self.create_code_change(code_file_manager)
                     created_code_change = True
@@ -129,7 +160,7 @@ def run_async_stream_and_parse_llm_response(
         asyncio.run(
             stream_and_parse_llm_response(messages, model, state, code_file_manager)
         )
-    except openai.error.InvalidRequestError as e:
+    except (openai.error.InvalidRequestError, openai.error.RateLimitError) as e:
         cprint(e, "red")
         exit()
     except KeyboardInterrupt:
@@ -138,6 +169,10 @@ def run_async_stream_and_parse_llm_response(
         if state.in_code_lines:
             state.code_changes = state.code_changes[:-1]
         logging.info("User interrupted response.")
+
+    state.code_changes = list(
+        filter(lambda change: not change.error, state.code_changes)
+    )
 
     state.time_elapsed = default_timer() - start_time
     return state
@@ -155,11 +190,20 @@ async def stream_and_parse_llm_response(
 
     printer = StreamingPrinter()
     printer_task = asyncio.create_task(printer.print_lines())
-    await _process_response(state, response, printer, code_file_manager)
-    printer.wrap_it_up()
-    await printer_task
-
-    logging.debug(f"LLM response:\n{state.message}")
+    try:
+        await _process_response(state, response, printer, code_file_manager)
+        printer.wrap_it_up()
+        await printer_task
+    except ModelError as e:
+        printer.wrap_it_up()
+        await printer_task
+        cprint("\n\nFatal error while processing model response:", "red")
+        cprint(e, color="red")
+        cprint("Using response up to this point.")
+        if e.unfinished_change:
+            state.code_changes = state.code_changes[:-1]
+    finally:
+        logging.debug(f"LLM response:\n{state.message}")
 
 
 async def _process_response(
@@ -176,7 +220,14 @@ async def _process_response(
             if content_line:
                 state.message += content_line
                 _process_content_line(state, content_line, printer, code_file_manager)
+
+    # This newline solves at least 5 edge cases singlehandedly
     _process_content_line(state, "\n", printer, code_file_manager)
+
+    # If the model forgot an @@end at the very end of it's message, we might as well add the change
+    if state.in_special_lines:
+        logging.info("Model forgot an @@end!")
+        _process_content_line(state, "@@end\n", printer, code_file_manager)
 
 
 def _process_content_line(
@@ -185,7 +236,9 @@ def _process_content_line(
     beginning = state.cur_line == ""
     state.cur_line += content
 
-    if state.in_code_lines or not state.in_special_lines:
+    if (
+        state.in_code_lines and not state.code_changes[-1].error
+    ) or not state.in_special_lines:
         to_print = state.parse_line_printing(content)
         prefix = (
             "+" + " " * (state.code_changes[-1].line_number_buffer - 1)
@@ -203,19 +256,29 @@ def _process_content_line(
 
         if created_code_change:
             cur_change = state.code_changes[-1]
-            if (
-                len(state.code_changes) < 2
-                or state.code_changes[-2].file != cur_change.file
-                or state.explained_since_change
-            ):
-                printer.add_string(get_file_name(cur_change))
-                printer.add_string(change_delimiter)
-            state.explained_since_change = False
-            printer.add_string(get_previous_lines(cur_change))
-            printer.add_string(get_removed_block(cur_change))
-            if not cur_change.action.has_additions():
-                printer.add_string(get_later_lines(cur_change))
-                printer.add_string(change_delimiter)
+            if cur_change.error:
+                logging.info(
+                    f"Model error when creating code change: {cur_change.error}"
+                )
+                printer.add_string("\nNot showing skipped change due to error:")
+                printer.add_string(cur_change.error, color="red")
+                printer.add_string(
+                    "Continuing model response...\n", color="light_green"
+                )
+            else:
+                if (
+                    len(state.code_changes) < 2
+                    or state.code_changes[-2].file != cur_change.file
+                    or state.explained_since_change
+                ):
+                    printer.add_string(get_file_name(cur_change))
+                    printer.add_string(change_delimiter)
+                state.explained_since_change = False
+                printer.add_string(get_previous_lines(cur_change))
+                printer.add_string(get_removed_block(cur_change))
+                if not cur_change.action.has_additions():
+                    printer.add_string(get_later_lines(cur_change))
+                    printer.add_string(change_delimiter)
 
         prefix = (
             "+" + " " * (state.code_changes[-1].line_number_buffer - 1)
@@ -223,8 +286,8 @@ def _process_content_line(
             else ""
         )
         color = "green" if state.in_code_lines else None
-        if to_print:
+        if to_print and not (state.in_code_lines and state.code_changes[-1].error):
             printer.add_string(prefix + to_print, end="", color=color)
-        if exited_code_lines:
+        if exited_code_lines and not state.code_changes[-1].error:
             printer.add_string(get_later_lines(state.code_changes[-1]))
             printer.add_string(change_delimiter)

--- a/tests/model_error_test.py
+++ b/tests/model_error_test.py
@@ -1,0 +1,286 @@
+from textwrap import dedent
+
+from mentat.app import run
+
+temp_file_name = "temp.py"
+template_insert_content = "# I inserted this comment"
+template_insert_expected_content = template_insert_content + "\n"
+template_double_insert_expected_content = (
+    template_insert_content + "\n\n" + template_insert_content
+)
+template_insert = dedent(f"""\
+    @@start
+    {{
+        "file": "{temp_file_name}",
+        "action": "insert",
+        "insert-after-line": 0,
+        "insert-before-line": 1
+    }}
+    @@code
+    {template_insert_content}
+    @@end
+    """)
+template_insert2 = dedent(f"""\
+    @@start
+    {{
+        "file": "{temp_file_name}",
+        "action": "insert",
+        "insert-after-line": 1,
+        "insert-before-line": 2
+    }}
+    @@code
+    {template_insert_content}
+    @@end
+    """)
+
+
+def error_test_template(
+    mock_call_llm_api,
+    mock_collect_user_input,
+    mock_setup_api_key,
+    changes,
+):
+    # Automatically set everything up given and use given changes
+    with open(temp_file_name, "w") as f:
+        f.write("")
+
+    mock_collect_user_input.side_effect = [
+        "Go!",
+        "y",
+        KeyboardInterrupt,
+    ]
+    mock_call_llm_api.set_generator_values([changes])
+
+    run([temp_file_name])
+    with open(temp_file_name, "r") as f:
+        content = f.read()
+    return content
+
+
+# These tests should not accept any changes after the invalid one
+def test_malformed_json(mock_call_llm_api, mock_collect_user_input, mock_setup_api_key):
+    # Should stop and only allow applying changes up to that point, not including malformed change
+    content = error_test_template(
+        mock_call_llm_api,
+        mock_collect_user_input,
+        mock_setup_api_key,
+        template_insert + dedent("""\
+        @@start
+        {{
+            "malformed-json: [,
+        }}
+        @@code
+        # My json is malformed :(
+        @@end
+        """) + template_insert2,
+    )
+    assert content == template_insert_expected_content
+
+
+def test_unknown_action(mock_call_llm_api, mock_collect_user_input, mock_setup_api_key):
+    # Should stop and only allow applying changes up to that point, not including unknown action change
+    content = error_test_template(
+        mock_call_llm_api,
+        mock_collect_user_input,
+        mock_setup_api_key,
+        template_insert + dedent(f"""\
+        @@start
+        {{
+            "file": "{temp_file_name}",
+            "action": "unknown",
+            "insert-after-line": 0,
+            "insert-before-line": 1
+        }}
+        @@code
+        # I am unknown
+        @@end
+        """) + template_insert2,
+    )
+    assert content == template_insert_expected_content
+
+
+def test_indicator(mock_call_llm_api, mock_collect_user_input, mock_setup_api_key):
+    # Test start indicator in change, code indicator outside change, code indicator inside code block,
+    # code indicator for action without code, and end indicator while not creating change
+    content = error_test_template(
+        mock_call_llm_api,
+        mock_collect_user_input,
+        mock_setup_api_key,
+        template_insert + dedent(f"""\
+        @@start
+        {{
+            "file": "{temp_file_name}",
+            "action": "insert",
+            "insert-after-line": 0,
+            "insert-before-line": 1
+        }}
+        @@code
+        @@start
+        # I am wrong
+        @@end
+        """) + template_insert2,
+    )
+    assert content == template_insert_expected_content
+
+    content = error_test_template(
+        mock_call_llm_api,
+        mock_collect_user_input,
+        mock_setup_api_key,
+        template_insert + dedent(f"""\
+        @@code
+        @@start
+        {{
+            "file": "{temp_file_name}",
+            "action": "insert",
+            "insert-after-line": 0,
+            "insert-before-line": 1
+        }}
+        @@code
+        # I am wrong
+        @@end
+        """) + template_insert2,
+    )
+    assert content == template_insert_expected_content
+
+    content = error_test_template(
+        mock_call_llm_api,
+        mock_collect_user_input,
+        mock_setup_api_key,
+        template_insert + dedent(f"""\
+        @@start
+        {{
+            "file": "{temp_file_name}",
+            "action": "insert",
+            "insert-after-line": 0,
+            "insert-before-line": 1
+        }}
+        @@code
+        @@code
+        # I am wrong
+        @@end
+        """) + template_insert2,
+    )
+    assert content == template_insert_expected_content
+
+    content = error_test_template(
+        mock_call_llm_api,
+        mock_collect_user_input,
+        mock_setup_api_key,
+        template_insert + dedent(f"""\
+        @@start
+        {{
+            "file": "{temp_file_name}",
+            "action": "remove",
+            "insert-after-line": 0,
+            "insert-before-line": 1
+        }}
+        @@code
+        # I am wrong
+        @@end
+        """) + template_insert2,
+    )
+    assert content == template_insert_expected_content
+
+    content = error_test_template(
+        mock_call_llm_api,
+        mock_collect_user_input,
+        mock_setup_api_key,
+        template_insert + dedent("""\
+        @@end
+        """) + template_insert2,
+    )
+    assert content == template_insert_expected_content
+
+
+# These tests should keep changes after the invalid change
+def test_no_line_numbers(
+    mock_call_llm_api, mock_collect_user_input, mock_setup_api_key
+):
+    # Should have line numbers
+    content = error_test_template(
+        mock_call_llm_api,
+        mock_collect_user_input,
+        mock_setup_api_key,
+        template_insert + dedent(f"""\
+        @@start
+        {{
+            "file": "{temp_file_name}",
+            "action": "replace"
+        }}
+        @@code
+        # I have no line numbers
+        @@end
+        """) + template_insert2,
+    )
+    assert content == template_double_insert_expected_content
+
+
+def test_invalid_line_numbers(
+    mock_call_llm_api, mock_collect_user_input, mock_setup_api_key
+):
+    # First line number should be <= the last line number
+    content = error_test_template(
+        mock_call_llm_api,
+        mock_collect_user_input,
+        mock_setup_api_key,
+        template_insert + dedent(f"""\
+        @@start
+        {{
+            "file": "{temp_file_name}",
+            "action": "replace",
+            "start-line": 10,
+            "end-line": 4
+        }}
+        @@code
+        # I have wrong line numbers
+        @@end
+        """) + template_insert2,
+    )
+    print(repr(content))
+    assert content == template_double_insert_expected_content
+
+
+def test_existing_file(mock_call_llm_api, mock_collect_user_input, mock_setup_api_key):
+    # Creating file that already exists should fail
+    content = error_test_template(
+        mock_call_llm_api,
+        mock_collect_user_input,
+        mock_setup_api_key,
+        template_insert + dedent(f"""\
+        @@start
+        {{
+            "file": "{temp_file_name}",
+            "action": "create-file"
+        }}
+        @@code
+        # I already exist
+        @@end
+        """) + template_insert2,
+    )
+    print(repr(content))
+    assert content == template_double_insert_expected_content
+
+
+def test_file_not_in_context(
+    mock_call_llm_api, mock_collect_user_input, mock_setup_api_key
+):
+    # Trying to access file not in context should fail
+    content = error_test_template(
+        mock_call_llm_api,
+        mock_collect_user_input,
+        mock_setup_api_key,
+        template_insert + dedent("""\
+        @@start
+        {
+            "file": "iamnotincontext",
+            "action": "insert",
+            "insert-after-line": 0,
+            "insert-before-line": 1
+        }
+        @@code
+        # I am not in context
+        @@end
+        """) + template_insert2,
+    )
+    print(repr(content))
+    assert content == template_double_insert_expected_content


### PR DESCRIPTION
Adds error handling for if the model messes up; if it's a non-fatal error, will keep accepting the models changes, otherwise it will stop and only use the existing changes.

I think the error code for codechange feels very clunky and messy; for the non fatal errors we can't throw an exception though, and this was the best I thought of. Let me know if you have any ideas to make it cleaner.