### PR TITLE
Add high-level code map to system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,27 @@ You'll need to have API access to GPT-4 to run Mentat. There are a few options t
 
 For custom configuration options see [configuration.md](docs/configuration.md)
 
+## (Optional) Install universal ctags 
+
+Installing [universal ctags](https://github.com/universal-ctags/ctags) is helpful if you want to use Mentat with many files. This enables Mentat to better understand your code by building a map of your entire codebase. 
+
+See the [official instructions](https://github.com/universal-ctags/ctags#the-latest-build-and-package) for installing univeresal ctags for your specific operating system, however you may be able to install a compatible version with one of the following commands:
+
+**OSX**
+```shell
+brew update && brew install universal-ctags
+```
+
+**Ubuntu**
+```shell
+sudo apt update && sudo apt install universal-ctags
+```
+
+**Windows**
+```shell
+choco install universal-ctags
+```
+
 
 # 🚀 Usage
 

--- a/mentat/app.py
+++ b/mentat/app.py
@@ -2,6 +2,7 @@ import argparse
 import glob
 import logging
 import os
+from textwrap import dedent
 from typing import Iterable, Optional
 
 from termcolor import cprint
@@ -100,11 +101,11 @@ def loop(
     )
     code_map = CodeMap(git_root, token_limit=2048)
     if code_map.ctags_disabled:
-        ctags_disabled_message = ctags_disabled_message = [
-            "There was an error with your universal ctags installation, disabling CodeMap.",
-            f"Reason: {code_map.ctags_disabled_reason}\n",
-        ]
-        ctags_disabled_message = "\n".join(ctags_disabled_message)
+        ctags_disabled_message = f"""
+            There was an error with your universal ctags installation, disabling CodeMap.
+            Reason: {code_map.ctags_disabled_reason}
+        """
+        ctags_disabled_message = dedent(ctags_disabled_message)
         cprint(ctags_disabled_message, color="yellow")
     conv = Conversation(config, cost_tracker, code_file_manager, code_map)
 

--- a/mentat/app.py
+++ b/mentat/app.py
@@ -99,6 +99,11 @@ def loop(
         git_root,
     )
     code_map = CodeMap(git_root, token_limit=2048)
+    if code_map.ctags_disabled:
+        cprint(
+            f"There was an error with your universal ctags installation, disabling CodeMap.\nReason: {code_map.ctags_disabled_reason}\n",
+            color="yellow",
+        )
     conv = Conversation(config, cost_tracker, code_file_manager, code_map)
 
     cprint("Type 'q' or use Ctrl-C to quit at any time.\n", color="cyan")

--- a/mentat/app.py
+++ b/mentat/app.py
@@ -100,10 +100,12 @@ def loop(
     )
     code_map = CodeMap(git_root, token_limit=2048)
     if code_map.ctags_disabled:
-        cprint(
-            f"There was an error with your universal ctags installation, disabling CodeMap.\nReason: {code_map.ctags_disabled_reason}\n",
-            color="yellow",
-        )
+        ctags_disabled_message = ctags_disabled_message = [
+            "There was an error with your universal ctags installation, disabling CodeMap.",
+            f"Reason: {code_map.ctags_disabled_reason}\n",
+        ]
+        ctags_disabled_message = "\n".join(ctags_disabled_message)
+        cprint(ctags_disabled_message, color="yellow")
     conv = Conversation(config, cost_tracker, code_file_manager, code_map)
 
     cprint("Type 'q' or use Ctrl-C to quit at any time.\n", color="cyan")

--- a/mentat/app.py
+++ b/mentat/app.py
@@ -98,7 +98,7 @@ def loop(
         config,
         git_root,
     )
-    code_map = CodeMap(git_root)
+    code_map = CodeMap(git_root, token_limit=2048)
     conv = Conversation(config, cost_tracker, code_file_manager, code_map)
 
     cprint("Type 'q' or use Ctrl-C to quit at any time.\n", color="cyan")

--- a/mentat/app.py
+++ b/mentat/app.py
@@ -9,6 +9,7 @@ from termcolor import cprint
 from .code_change import CodeChange
 from .code_change_display import print_change
 from .code_file_manager import CodeFileManager
+from .code_map import CodeMap
 from .config_manager import ConfigManager, mentat_dir_path
 from .conversation import Conversation
 from .errors import MentatError, UserError
@@ -97,7 +98,8 @@ def loop(
         config,
         git_root,
     )
-    conv = Conversation(config, cost_tracker, code_file_manager)
+    code_map = CodeMap(git_root)
+    conv = Conversation(config, cost_tracker, code_file_manager, code_map)
 
     cprint("Type 'q' or use Ctrl-C to quit at any time.\n", color="cyan")
     cprint("What can I do for you?", color="light_blue")

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -1,13 +1,10 @@
 import json
-import logging
 import os
 import re
 import subprocess
 import tempfile
 from pathlib import Path
 from typing import List
-
-from ipdb import set_trace
 
 from .llm_api import count_tokens
 
@@ -119,7 +116,7 @@ def _get_file_map(file_paths: List[str]):
 
 
 class CodeMap:
-    def __init__(self, git_root: str, token_limit: int | None = None):
+    def __init__(self, git_root: str, token_limit: int | None = 2048):
         self.git_root = git_root
         self.token_limit = token_limit
 

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -7,6 +7,10 @@ from typing import DefaultDict, Set, Tuple
 
 from ipdb import set_trace
 
+# To-Do
+# 1. prevent mentat editing files which exist in the code map but not in the code message
+# 2. create a mini-code map
+
 
 def get_git_root():
     try:
@@ -109,9 +113,9 @@ def _get_message(ctags: DefaultDict[str, Set[Tuple[str, ...]]]):
         file_maps.append(output)
 
     message = f"""
-        Below is a map of all files tracked by git in this project. Let the user know 
-        if you think they should add the complete source code of any files to this 
-        chat.
+        Below is a read-only code map of all files tracked by git in this project. 
+        If you need to edit any of the files in this code map that aren't in the current context,
+        don't try to edit them and instead give the user the filepaths of what they should add to this context.
     """
     message = message.strip()
     message = re.sub(r"[\n\s]+", " ", message)

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -32,8 +32,8 @@ def _get_code_map(root: str, file_path: str, exclude_signatures: bool = False):
         try:
             tag = json.loads(output_line)
         except json.decoder.JSONDecodeError as err:
-            cprint(f"Error parsing ctags output: {err}")
-            cprint(repr(output_line))
+            cprint(f"Error parsing ctags output: {err}", color="yellow")
+            cprint(f"{repr(output_line)}\n", color="yellow")
             continue
 
         scope = tag.get("scope")

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -1,5 +1,4 @@
 import json
-import re
 import subprocess
 import tempfile
 from pathlib import Path

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -1,26 +1,15 @@
 import json
+import logging
+import os
 import re
 import subprocess
-from collections import defaultdict
+import tempfile
 from pathlib import Path
-from typing import DefaultDict, List, Set, Tuple
+from typing import List
 
 from ipdb import set_trace
 
 from .llm_api import count_tokens
-
-
-def get_git_root():
-    try:
-        git_root = (
-            subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
-            .strip()
-            .decode("utf-8")
-        )
-    except subprocess.CalledProcessError:
-        git_root = None
-
-    return git_root
 
 
 def get_git_files(git_root: str, absolute_paths: bool = False) -> List[str]:
@@ -37,93 +26,76 @@ def get_git_files(git_root: str, absolute_paths: bool = False) -> List[str]:
     return git_files
 
 
-def _build_ctags(root: str, file_paths: List[str]):
-    ctags: DefaultDict[str, Set[Tuple[str, ...]]] = defaultdict(set)
+def _get_code_map(root: str, file_path: str, exclude_signatures: bool = False):
+    # Create ctags from executable in a subprocess
+    ctags_cmd_args = [
+        "--extras=-F",
+        "--input-encoding=utf-8",
+        "--output-format=json",
+        "--output-encoding=utf-8",
+    ]
+    if exclude_signatures:
+        ctags_cmd_args.append("--fields=-s")
+    else:
+        ctags_cmd_args.append("--fields=+S")
+    ctags_cmd = ["ctags", *ctags_cmd_args, str(Path(root).joinpath(file_path))]
+    output = subprocess.check_output(ctags_cmd, stderr=subprocess.PIPE).decode("utf-8")
+    output_lines = output.splitlines()
 
-    for file_path in file_paths:
-        ctags_cmd = [
-            "ctags",
-            "--fields=+S",
-            "--extras=-F",
-            "--input-encoding=utf-8",
-            "--output-format=json",
-            "--output-encoding=utf-8",
-            str(Path(root).joinpath(file_path)),
-        ]
-        output = subprocess.check_output(ctags_cmd, stderr=subprocess.PIPE).decode(
-            "utf-8"
-        )
-        output_lines = output.splitlines()
+    # Extract subprocess stdout into python objects
+    ctags = set()
+    for output_line in output_lines:
+        try:
+            tag = json.loads(output_line)
+        except json.decoder.JSONDecodeError as err:
+            print(f"Error parsing ctags output: {err}")
+            print(repr(output_line))
+            continue
 
-        for output_line in output_lines:
-            try:
-                tag = json.loads(output_line)
-            except json.decoder.JSONDecodeError as err:
-                print(f"Error parsing ctags output: {err}")
-                print(repr(output_line))
-                continue
+        scope = tag.get("scope")
+        kind = tag.get("kind")
+        name = tag.get("name")
+        signature = tag.get("signature")
 
-            scope = tag.get("scope")
-            kind = tag.get("kind")
-            name = tag.get("name")
-            signature = tag.get("signature")
+        last = name
+        if signature:
+            last += " " + signature
 
-            last = name
-            if signature:
-                last += " " + signature
+        res = [file_path]
+        if scope:
+            res.append(scope)
+        res += [kind, last]
 
-            res = [file_path]
-            if scope:
-                res.append(scope)
-            res += [kind, last]
+        ctags.add(tuple(res))
 
-            ctags[file_path].add(tuple(res))
+    # Build LLM-readable string representation of ctag objects
+    sorted_tags = sorted(ctags)
+    output = ""
+    last = [None] * len(sorted_tags[0])
+    tab = "\t"
+    for tag in sorted_tags:
+        tag = list(tag)
 
-    return ctags
+        num_common = 0
+        for i in range(len(last) + 1):
+            if i == len(last):
+                break
+            if last[i] != tag[i]:
+                num_common = i
+                break
 
+        indent = tab * num_common
+        rest = tag[num_common:]
 
-def _get_code_map_message(ctags: DefaultDict[str, Set[Tuple[str, ...]]]):
-    file_maps = []
-    for ctags_ in ctags.values():
-        sorted_tags = sorted(ctags_)
+        for item in rest:
+            output += indent + item + "\n"
+            indent += tab
+        last = tag
 
-        output = ""
-        last = [None] * len(sorted_tags[0])
-        tab = "\t"
-        for tag in sorted_tags:
-            tag = list(tag)
-
-            num_common = 0
-            for i in range(len(last) + 1):
-                if i == len(last):
-                    break
-                if last[i] != tag[i]:
-                    num_common = i
-                    break
-
-            indent = tab * num_common
-            rest = tag[num_common:]
-
-            for item in rest:
-                output += indent + item + "\n"
-                indent += tab
-            last = tag
-
-        file_maps.append(output)
-
-    message = f"""
-        Below is a read-only code map of all files tracked by git in this project. 
-        If you need to edit any of the files in this code map that aren't in the current context,
-        don't try to edit them and instead give the user the filepaths of what they should add to this context.
-    """
-    message = message.strip()
-    message = re.sub(r"[\n\s]+", " ", message)
-    message += "\n\n" + "\n".join(file_maps)
-
-    return message
+    return output
 
 
-def _get_file_map_message(file_paths: List[str]):
+def _get_file_map(file_paths: List[str]):
     tree = {}
     for file_path in file_paths:
         parts = file_path.split("/")
@@ -141,22 +113,117 @@ def _get_file_map_message(file_paths: List[str]):
             s += tree_to_string(tree[key], indent + 1)
         return s
 
-    return tree_to_string(tree)
+    file_map_tree = tree_to_string(tree)
+
+    return file_map_tree
 
 
-def get_code_map_message(token_limit: int | None = None):
-    git_root = get_git_root()
-    if not git_root:
-        return
-    git_file_paths = get_git_files(git_root)
-    ctags = _build_ctags(git_root, git_file_paths)
+class CodeMap:
+    def __init__(self, git_root: str, token_limit: int | None = None):
+        self.git_root = git_root
+        self.token_limit = token_limit
 
-    code_map_message = _get_code_map_message(ctags)
-    code_map_message_token_count = count_tokens(code_map_message)
-    if token_limit is None or code_map_message_token_count <= token_limit:
-        return code_map_message
+        self.ctags_disabled = True
+        self.ctags_disabled_reason = ""
 
-    file_map_message = _get_file_map_message(git_file_paths)
-    file_map_message_token_count = count_tokens(file_map_message)
-    if file_map_message_token_count <= token_limit:
-        return file_map_message
+        self._check_ctags_executable()
+
+    def _check_ctags_executable(self):
+        try:
+            cmd = ["ctags", "--version"]
+            output = subprocess.check_output(cmd, stderr=subprocess.PIPE).decode(
+                "utf-8"
+            )
+            output = output.lower()
+
+            cmd = " ".join(cmd)
+            if "universal ctags" not in output:
+                self.ctags_disabled_reason = (
+                    f"{cmd} does not claim to be universal ctags"
+                )
+                return
+            if "+json" not in output:
+                self.ctags_disabled_reason = f"{cmd} does not list +json support"
+                return
+
+            with tempfile.TemporaryDirectory() as tempdir:
+                hello_py = os.path.join(tempdir, "hello.py")
+                with open(hello_py, "w", encoding="utf-8") as f:
+                    f.write("def hello():\n    print('Hello, world!')\n")
+                _get_code_map(tempdir, hello_py)
+        except FileNotFoundError:
+            self.ctags_disabled_reason = f"ctags executable not found"
+            return
+        except Exception as e:
+            self.ctags_disabled_reason = f"error running universal-ctags: {e}"
+            return
+
+        self.ctags_disabled = False
+
+    def _get_code_map_message(
+        self, root: str, file_paths: List[str], exclude_signatures: bool = False
+    ) -> str | None:
+        code_maps = []
+        code_maps_token_count = 0
+        for file_path in file_paths:
+            code_map = _get_code_map(
+                root, file_path, exclude_signatures=exclude_signatures
+            )
+            code_map_token_count = count_tokens(code_map)
+
+            if self.token_limit is not None and code_map_token_count > self.token_limit:
+                if exclude_signatures is True:
+                    return
+                return self._get_code_map_message(
+                    root, file_paths, exclude_signatures=True
+                )
+
+            code_maps.append(code_map)
+            code_maps_token_count += code_map_token_count
+
+        message = f"""
+            Below is a read-only code map of all files tracked by git in this project. 
+            If you need to edit any of the files in this code map that aren't in the current context,
+            don't try to edit them and instead give the user the filepaths of what they should add to this context.
+        """
+        message = message.strip()
+        message = re.sub(r"[\n\s]+", " ", message)
+        message += "\n\n" + "\n".join(code_maps)
+
+        message_token_count = count_tokens(message)
+        if self.token_limit is not None and message_token_count > self.token_limit:
+            if exclude_signatures is True:
+                return
+            return self._get_code_map_message(root, file_paths, exclude_signatures=True)
+
+        return message
+
+    def _get_file_map_message(self, file_paths: List[str]) -> str | None:
+        file_map_tree = _get_file_map(file_paths)
+
+        message = f"""
+            Below is a read-only code map of all files tracked by git in this project. 
+            If you need to edit any of the files in this code map that aren't in the current context,
+            don't try to edit them and instead give the user the filepaths of what they should add to this context.
+        """
+        message = message.strip()
+        message = re.sub(r"[\n\s]+", " ", message)
+        message += "\n\n" + file_map_tree
+
+        message_token_count = count_tokens(message)
+        if self.token_limit is not None and message_token_count > self.token_limit:
+            return
+
+        return message
+
+    def get_message(self):
+        git_file_paths = get_git_files(self.git_root)
+
+        if not self.ctags_disabled:
+            code_map_message = self._get_code_map_message(self.git_root, git_file_paths)
+            if code_map_message is not None:
+                return code_map_message
+
+        file_map_message = self._get_file_map_message(git_file_paths)
+        if file_map_message is not None:
+            return file_map_message

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -1,0 +1,91 @@
+import json
+import subprocess
+from collections import defaultdict
+
+from ipdb import set_trace
+
+from .code_file_manager import CodeFileManager
+
+
+class CodeMap:
+    def __init__(self, code_file_manager: CodeFileManager):
+        self.code_file_manager = code_file_manager
+        self.ctags = defaultdict(set)
+
+    def build(self):
+        for file_path in self.code_file_manager.file_paths:
+            ctags_cmd = [
+                "ctags",
+                "--fields=+S",
+                "--extras=-F",
+                "--input-encoding=utf-8",
+                "--output-format=json",
+                "--output-encoding=utf-8",
+                file_path,
+            ]
+            output = subprocess.check_output(ctags_cmd, stderr=subprocess.PIPE).decode(
+                "utf-8"
+            )
+            output_lines = output.splitlines()
+
+            for output_line in output_lines:
+                try:
+                    tag = json.loads(output_line)
+                except json.decoder.JSONDecodeError as err:
+                    print(f"Error parsing ctags output: {err}")
+                    print(repr(output_line))
+                    continue
+
+                scope = tag.get("scope")
+                kind = tag.get("kind")
+                name = tag.get("name")
+                signature = tag.get("signature")
+
+                last = name
+                if signature:
+                    last += " " + signature
+
+                # TODO: get relative filepath
+                rel_fname = file_path
+
+                res = [rel_fname]
+                if scope:
+                    res.append(scope)
+                res += [kind, last]
+
+                self.ctags[file_path].add(tuple(res))
+
+    def get_message(self):
+        self.build()  # TODO: cache this?
+
+        file_messages = []
+        for file, ctags in self.ctags.items():
+            sorted_tags = sorted(ctags)
+
+            output = ""
+            last = [None] * len(sorted_tags[0])
+            tab = "\t"
+            for tag in sorted_tags:
+                tag = list(tag)
+
+                for i in range(len(last) + 1):
+                    if i == len(last):
+                        break
+                    if last[i] != tag[i]:
+                        break
+
+                num_common = i
+
+                indent = tab * num_common
+                rest = tag[num_common:]
+
+                for j, item in enumerate(rest):
+                    output += indent + item + "\n"
+                    indent += tab
+                last = tag
+
+            file_messages.append(output)
+
+        message = "\n".join(file_messages)
+
+        return message

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -1,91 +1,132 @@
 import json
+import re
 import subprocess
 from collections import defaultdict
+from pathlib import Path
+from typing import DefaultDict, Set, Tuple
 
 from ipdb import set_trace
 
-from .code_file_manager import CodeFileManager
+
+def get_git_root():
+    try:
+        git_root = (
+            subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
+            .strip()
+            .decode("utf-8")
+        )
+    except subprocess.CalledProcessError:
+        git_root = None
+
+    return git_root
 
 
-class CodeMap:
-    def __init__(self, code_file_manager: CodeFileManager):
-        self.code_file_manager = code_file_manager
-        self.ctags = defaultdict(set)
+def get_git_files():
+    git_files = (
+        subprocess.check_output(["git", "ls-files"]).decode("utf-8").splitlines()
+    )
 
-    def build(self):
-        for file_path in self.code_file_manager.file_paths:
-            ctags_cmd = [
-                "ctags",
-                "--fields=+S",
-                "--extras=-F",
-                "--input-encoding=utf-8",
-                "--output-format=json",
-                "--output-encoding=utf-8",
-                file_path,
-            ]
-            output = subprocess.check_output(ctags_cmd, stderr=subprocess.PIPE).decode(
-                "utf-8"
-            )
-            output_lines = output.splitlines()
+    return git_files
 
-            for output_line in output_lines:
-                try:
-                    tag = json.loads(output_line)
-                except json.decoder.JSONDecodeError as err:
-                    print(f"Error parsing ctags output: {err}")
-                    print(repr(output_line))
-                    continue
 
-                scope = tag.get("scope")
-                kind = tag.get("kind")
-                name = tag.get("name")
-                signature = tag.get("signature")
+def _build_ctags():
+    ctags: DefaultDict[str, Set[Tuple[str, ...]]] = defaultdict(set)
 
-                last = name
-                if signature:
-                    last += " " + signature
+    git_root = get_git_root()
+    if git_root is None:
+        return
+    git_file_paths = get_git_files()
 
-                # TODO: get relative filepath
-                rel_fname = file_path
+    for file_path in git_file_paths:
+        ctags_cmd = [
+            "ctags",
+            "--fields=+S",
+            "--extras=-F",
+            "--input-encoding=utf-8",
+            "--output-format=json",
+            "--output-encoding=utf-8",
+            str(Path(git_root).joinpath(file_path)),
+        ]
+        output = subprocess.check_output(ctags_cmd, stderr=subprocess.PIPE).decode(
+            "utf-8"
+        )
+        output_lines = output.splitlines()
 
-                res = [rel_fname]
-                if scope:
-                    res.append(scope)
-                res += [kind, last]
+        for output_line in output_lines:
+            try:
+                tag = json.loads(output_line)
+            except json.decoder.JSONDecodeError as err:
+                print(f"Error parsing ctags output: {err}")
+                print(repr(output_line))
+                continue
 
-                self.ctags[file_path].add(tuple(res))
+            scope = tag.get("scope")
+            kind = tag.get("kind")
+            name = tag.get("name")
+            signature = tag.get("signature")
 
-    def get_message(self):
-        self.build()  # TODO: cache this?
+            last = name
+            if signature:
+                last += " " + signature
 
-        file_messages = []
-        for file, ctags in self.ctags.items():
-            sorted_tags = sorted(ctags)
+            res = [file_path]
+            if scope:
+                res.append(scope)
+            res += [kind, last]
 
-            output = ""
-            last = [None] * len(sorted_tags[0])
-            tab = "\t"
-            for tag in sorted_tags:
-                tag = list(tag)
+            ctags[file_path].add(tuple(res))
 
-                for i in range(len(last) + 1):
-                    if i == len(last):
-                        break
-                    if last[i] != tag[i]:
-                        break
+    return ctags
 
-                num_common = i
 
-                indent = tab * num_common
-                rest = tag[num_common:]
+def _get_message(ctags: DefaultDict[str, Set[Tuple[str, ...]]]):
+    file_maps = []
+    for ctags in ctags.values():
+        sorted_tags = sorted(ctags)
 
-                for j, item in enumerate(rest):
-                    output += indent + item + "\n"
-                    indent += tab
-                last = tag
+        output = ""
+        last = [None] * len(sorted_tags[0])
+        tab = "\t"
+        for tag in sorted_tags:
+            tag = list(tag)
 
-            file_messages.append(output)
+            num_common = 0
+            for i in range(len(last) + 1):
+                if i == len(last):
+                    break
+                if last[i] != tag[i]:
+                    num_common = i
+                    break
 
-        message = "\n".join(file_messages)
+            indent = tab * num_common
+            rest = tag[num_common:]
 
-        return message
+            for item in rest:
+                output += indent + item + "\n"
+                indent += tab
+            last = tag
+
+        file_maps.append(output)
+
+    message = f"""
+        Below is a map of all files tracked by git in this project. Let the user know 
+        if you think they should add the complete source code of any files to this 
+        chat.
+    """
+    message = message.strip()
+    message = re.sub(r"[\n\s]+", " ", message)
+    message += "\n\n" + "\n".join(file_maps)
+
+    return message
+
+
+def get_code_map_message():
+    is_git_repo = True if get_git_root() is not None else False
+    if not is_git_repo:
+        return
+    ctags = _build_ctags()
+    if ctags is None:
+        return
+    message = _get_message(ctags)
+
+    return message

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -27,20 +27,22 @@ class Conversation:
         tokens = count_tokens(code_file_manager.get_code_message()) + count_tokens(
             system_prompt
         )
-        token_limit = 32768 if self.allow_32k else 8192
-        if tokens > token_limit:
+        self.token_limit = 32768 if self.allow_32k else 8192
+        if tokens > self.token_limit:
             raise KeyboardInterrupt(
-                f"Included files already exceed token limit ({tokens} / {token_limit})."
+                f"Included files already exceed token limit ({tokens} / {self.token_limit})."
                 " Please try running again with a reduced number of files."
             )
-        elif tokens + 1000 > token_limit:
+        elif tokens + 1000 > self.token_limit:
             cprint(
                 f"Warning: Included files are close to token limit ({tokens} /"
-                f" {token_limit}), you may not be able to have a long conversation.",
+                f" {self.token_limit}), you may not be able to have a long conversation.",
                 "red",
             )
         else:
-            cprint(f"File and prompt token count: {tokens} / {token_limit}", "cyan")
+            cprint(
+                f"File and prompt token count: {tokens} / {self.token_limit}", "cyan"
+            )
 
     def add_system_message(self, message: str):
         self.messages.append({"role": "system", "content": message})
@@ -57,21 +59,23 @@ class Conversation:
         code_message = self.code_file_manager.get_code_message()
         system_message = code_message
 
-        if self.code_map:
-            code_map_message = self.code_map.get_message()
-            if code_map_message is not None:
-                code_map_message_token_count = count_tokens(code_map_message)
-                prompt_token_count = 0
-                prompt_token_count += count_tokens(code_message)
-                for message in messages:
-                    prompt_token_count += count_tokens(message["content"])
-                token_buffer = 1000
-                token_limit = 32768 if self.allow_32k else 8192
-                token_count = (
-                    prompt_token_count + code_map_message_token_count + token_buffer
+        if self.code_map and (code_map_message := self.code_map.get_message()):
+            code_map_message_token_count = count_tokens(code_map_message)
+            prompt_token_count = 0
+            prompt_token_count += count_tokens(code_message)
+            for message in messages:
+                prompt_token_count += count_tokens(message["content"])
+            token_buffer = 1000
+            token_count = (
+                prompt_token_count + code_map_message_token_count + token_buffer
+            )
+            if token_count < self.token_limit:
+                system_message += f"\n{code_map_message}"
+            else:
+                cprint(
+                    "Excluding CodeMap from system message.\nReason: not enough tokens available in model context.\n",
+                    color="yellow",
                 )
-                if token_count < token_limit:
-                    system_message = "\n".join([code_message, code_map_message])
 
         messages.append({"role": "system", "content": system_message})
 

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -30,13 +30,15 @@ class Conversation:
         self.token_limit = 32768 if self.allow_32k else 8192
         if tokens > self.token_limit:
             raise KeyboardInterrupt(
-                f"Included files already exceed token limit ({tokens} / {self.token_limit})."
-                " Please try running again with a reduced number of files."
+                f"Included files already exceed token limit ({tokens} /"
+                f" {self.token_limit}). Please try running again with a reduced number"
+                " of files."
             )
         elif tokens + 1000 > self.token_limit:
             cprint(
                 f"Warning: Included files are close to token limit ({tokens} /"
-                f" {self.token_limit}), you may not be able to have a long conversation.",
+                f" {self.token_limit}), you may not be able to have a long"
+                " conversation.",
                 "red",
             )
         else:

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -1,7 +1,9 @@
+from ipdb import set_trace
 from termcolor import cprint
 
 from .code_change import CodeChange
 from .code_file_manager import CodeFileManager
+from .code_map import CodeMap
 from .config_manager import ConfigManager
 from .llm_api import CostTracker, check_model_availability, choose_model, count_tokens
 from .parsing import run_async_stream_and_parse_llm_response
@@ -19,6 +21,7 @@ class Conversation:
         self.add_system_message(system_prompt)
         self.cost_tracker = cost_tracker
         self.code_file_manager = code_file_manager
+        self.code_map = CodeMap(self.code_file_manager)
         self.allow_32k = check_model_availability(config.allow_32k())
 
         tokens = count_tokens(code_file_manager.get_code_message()) + count_tokens(
@@ -52,9 +55,28 @@ class Conversation:
         messages = self.messages.copy()
 
         code_message = self.code_file_manager.get_code_message()
-        messages.append({"role": "system", "content": code_message})
+
+        code_map_message = self.code_map.get_message()
+        code_map_message_token_count = count_tokens(code_map_message)
+
+        prompt_token_count = 0
+        prompt_token_count += count_tokens(code_message)
+        for message in messages:
+            prompt_token_count += count_tokens(message["content"])
+
+        token_buffer = 500
+        token_limit = 32768 if self.allow_32k else 8192
+        token_count = prompt_token_count + code_map_message_token_count + token_buffer
+        if token_count > token_limit:
+            system_message = code_map_message
+        else:
+            system_message = "\n".join([code_message, code_map_message])
+
+        messages.append({"role": "system", "content": system_message})
 
         model, num_prompt_tokens = choose_model(messages, self.allow_32k)
+
+        set_trace()
 
         state = run_async_stream_and_parse_llm_response(
             messages, model, self.code_file_manager

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -3,7 +3,7 @@ from termcolor import cprint
 
 from .code_change import CodeChange
 from .code_file_manager import CodeFileManager
-from .code_map import get_code_map_message, get_git_root
+from .code_map import get_code_map_message
 from .config_manager import ConfigManager
 from .llm_api import CostTracker, check_model_availability, choose_model, count_tokens
 from .parsing import run_async_stream_and_parse_llm_response
@@ -69,9 +69,8 @@ class Conversation:
                 prompt_token_count + code_map_message_token_count + token_buffer
             )
 
-            set_trace()
-
             if token_count < token_limit:
+                set_trace()
                 system_message = "\n".join([code_message, code_map_message])
 
         messages.append({"role": "system", "content": system_message})

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -1,4 +1,3 @@
-from ipdb import set_trace
 from termcolor import cprint
 
 from .code_change import CodeChange
@@ -72,7 +71,6 @@ class Conversation:
                     prompt_token_count + code_map_message_token_count + token_buffer
                 )
                 if token_count < token_limit:
-                    set_trace()
                     system_message = "\n".join([code_message, code_map_message])
 
         messages.append({"role": "system", "content": system_message})

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -3,7 +3,7 @@ from termcolor import cprint
 
 from .code_change import CodeChange
 from .code_file_manager import CodeFileManager
-from .code_map import get_code_map_message
+from .code_map import CodeMap
 from .config_manager import ConfigManager
 from .llm_api import CostTracker, check_model_availability, choose_model, count_tokens
 from .parsing import run_async_stream_and_parse_llm_response
@@ -16,11 +16,13 @@ class Conversation:
         config: ConfigManager,
         cost_tracker: CostTracker,
         code_file_manager: CodeFileManager,
+        code_map: CodeMap | None = None,
     ):
         self.messages = []
         self.add_system_message(system_prompt)
         self.cost_tracker = cost_tracker
         self.code_file_manager = code_file_manager
+        self.code_map = code_map
         self.allow_32k = check_model_availability(config.allow_32k())
 
         tokens = count_tokens(code_file_manager.get_code_message()) + count_tokens(
@@ -56,22 +58,22 @@ class Conversation:
         code_message = self.code_file_manager.get_code_message()
         system_message = code_message
 
-        code_map_message = get_code_map_message()
-        if code_map_message is not None:
-            code_map_message_token_count = count_tokens(code_map_message)
-            prompt_token_count = 0
-            prompt_token_count += count_tokens(code_message)
-            for message in messages:
-                prompt_token_count += count_tokens(message["content"])
-            token_buffer = 1000
-            token_limit = 32768 if self.allow_32k else 8192
-            token_count = (
-                prompt_token_count + code_map_message_token_count + token_buffer
-            )
-
-            if token_count < token_limit:
-                set_trace()
-                system_message = "\n".join([code_message, code_map_message])
+        if self.code_map:
+            code_map_message = self.code_map.get_message()
+            if code_map_message is not None:
+                code_map_message_token_count = count_tokens(code_map_message)
+                prompt_token_count = 0
+                prompt_token_count += count_tokens(code_message)
+                for message in messages:
+                    prompt_token_count += count_tokens(message["content"])
+                token_buffer = 1000
+                token_limit = 32768 if self.allow_32k else 8192
+                token_count = (
+                    prompt_token_count + code_map_message_token_count + token_buffer
+                )
+                if token_count < token_limit:
+                    set_trace()
+                    system_message = "\n".join([code_message, code_map_message])
 
         messages.append({"role": "system", "content": system_message})
 

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -83,6 +83,19 @@ class Conversation:
                 token_limit=code_map_message_token_limit
             )
             if code_map_message:
+                match (code_map_message.level):
+                    case "signatures":
+                        cprint_message_level = "full syntax tree"
+                    case "no_signatures":
+                        cprint_message_level = "partial syntax tree"
+                    case "filenames":
+                        cprint_message_level = "filepaths only"
+                    case _:
+                        raise Exception(
+                            f"Unknown CodeMapMessage level '{code_map_message.level}'"
+                        )
+                cprint_message = f"\nIncluding CodeMap ({cprint_message_level})"
+                cprint(cprint_message, color="green")
                 system_message += f"\n{code_map_message}"
             else:
                 cprint_message = [

--- a/mentat/prompts.py
+++ b/mentat/prompts.py
@@ -1,129 +1,146 @@
-system_prompt = (
-    "You are part of an automated coding system. As such, responses must adhere"
-    " strictly to the required format, so they can be parsed programmaticaly. Your"
-    " input will consist of a user request, the contents of code files, and sometimes"
-    " the git diff of current code files."
-    " The request may be to add a new feature, update the code, fix a"
-    " bug, add comments or docstrings, etc.\nThe first part of your response should"
-    " contain an brief summary of the changes you plan to make, then a list of the"
-    " changes. Ensure you plan ahead, like planning to add imports for things you need"
-    " to use in your changes, etc. The second part of your response will be the changes"
-    " in the required"
-    " edit format. Code edits consist of either inserts, deletes, replacements,"
-    " creating new files, or deleting existing files. They"
-    " can be of multiple lines of code. Edit description blocks start with @@start and"
-    " end with @@end. If the edit is a delete or delete-file, then the block should"
-    " only"
-    " contain a"
-    " JSON formatted section. In insert, replace, and create-file blocks, there must"
-    " be a"
-    " second"
-    " section containing the new line or lines of code. The JSON section and code"
-    " section are separated by a line containing just @@code.\nIf the request requires"
-    " clarification or the user is asking for something other than code changes, such"
-    " as design ideas, don't return any edit description blocks."
-    """
+import re
 
-To demonstrate the response format, here's an example user request, followed by an example response:
+system_prompt_prefix = """
+    You are part of an automated coding system. As such, responses must adhere
+    strictly to the required format, so they can be parsed programmaticaly. 
 
+    Your input will consist of a user request, the contents of code files, sometimes a
+    high-level code map of tracked files in the current git repository,
+    and sometimes the git diff of current code files.
 
-Code Files:
+    The request may be to add a new feature, update the code, fix a
+    bug, add comments or docstrings, etc.
+    
+    Your response should be either to make code edits or ask the user for the source
+    code of additional files.
+    
+    1. If you have the source code for all nessesary files to make edits:
+    
+    The first part of your response should contain an brief summary of the changes
+    you plan to make, then a list of the changes. Ensure you plan ahead, like 
+    planning to add imports for things you need to use in your changes, etc.
+    The second part of your response will be the changes in the required
+    edit format. Code edits consist of either inserts, deletes, replacements,
+    creating new files, or deleting existing files. They can be of multiple
+    lines of code. Edit description blocks start with @@start and end with @@end.
+    If the edit is a delete or delete-file, then the block should only contain a
+    JSON formatted section. In insert, replace, and create-file blocks, there
+    must be a second section containing the new line or lines of code.
+    The JSON section and code section are separated by a line containing just
+    @@code.
+    If the request requires clarification or the user is asking for something
+    other than code changes, such as design ideas, don't return any edit
+    description blocks.
 
-core/script.py
-1:
-2:def say_hello(name):
-3:    print(f"Hello {name}!")
-4:
-5:
-6:def say_goodbye():
-7:    print("Goodbye!")
-8:
-9:
-10:def main(name):
-11:    say_hello(name)
-12:    say_goodbye()
-13:    print("Done!")
-14:
-
-core/hello_world.py
-1:
-2:def hello_world():
-3:    print("Hello, World!")
-4:
-
-User Request:
-After saying hello, if the user's name is "Bob", say "Nice to see you again!" on another line.
-Add a function to get the user's name and use it in main instead of taking name as an argument.
-The new function should be in a separate file called utils.py. Stop saying "Done!". Finally,
-delete the hello_world.py file.
-
-
-Example Response:
-
-I will make the modifications to script.py and create the new file, importing from it in script.py.
-
-Steps:
-1. Modify say_hello, adding the case for Bob.
-2. Create utils.py with a function to get the user's name.
-3. Import the new function in script.py.
-4. Modify main to use the new function instead of taking name as an argument.
-5. Remove the line printing "Done!".
-6. Delete file hello_world.py
-
-@@start
-{
-    "file": "core/script.py",
-    "action": "insert",
-    "insert-after-line": 3,
-    "insert-before-line": 4
-}
-@@code
-    if name == "Bob":
-        print("Nice to see you again!")
-@@end
-@@start
-{
-    "file": "core/utils.py",
-    "action": "create-file"
-}
-@@code
-def get_name():
-    return input("Enter your name: ")
-@@end
-@@start
-{
-    "file": "core/script.py",
-    "action": "insert",
-    "insert-after-line": 0,
-    "insert-before-line": 1
-}
-@@code
-from core.utils import get_name
-@@end
-@@start
-{
-    "file": "core/script.py",
-    "action": "replace",
-    "start-line": 10,
-    "end-line": 10
-}
-@@code
-def main():
-    name = get_name()
-@@end
-@@start
-{
-    "file": "core/script.py",
-    "action": "delete",
-    "start-line": 13,
-    "end-line": 13
-}
-@@end
-@@start
-{
-    "file": "core/hello_world.py",
-    "action": "delete-file",
-}
-@@end
+    2. If you need to make changes to files that you don't have the full source code of 
+    (only the high-level code map), tell the user which files you need the source code
+    for so you can make edits correctly.
 """
-)
+system_prompt_prefix = system_prompt_prefix.strip()
+system_prompt_prefix = re.sub(r"[\n\s]+", " ", system_prompt_prefix)
+
+system_prompt_example = """
+    To demonstrate the response format, here's an example user request, followed by an example response:
+
+
+    Code Files:
+
+    core/script.py
+    1:
+    2:def say_hello(name):
+    3:    print(f"Hello {name}!")
+    4:
+    5:
+    6:def say_goodbye():
+    7:    print("Goodbye!")
+    8:
+    9:
+    10:def main(name):
+    11:    say_hello(name)
+    12:    say_goodbye()
+    13:    print("Done!")
+    14:
+
+    core/hello_world.py
+    1:
+    2:def hello_world():
+    3:    print("Hello, World!")
+    4:
+
+    User Request:
+    After saying hello, if the user's name is "Bob", say "Nice to see you again!" on another line.
+    Add a function to get the user's name and use it in main instead of taking name as an argument.
+    The new function should be in a separate file called utils.py. Stop saying "Done!". Finally,
+    delete the hello_world.py file.
+
+
+    Example Response:
+
+    I will make the modifications to script.py and create the new file, importing from it in script.py.
+
+    Steps:
+    1. Modify say_hello, adding the case for Bob.
+    2. Create utils.py with a function to get the user's name.
+    3. Import the new function in script.py.
+    4. Modify main to use the new function instead of taking name as an argument.
+    5. Remove the line printing "Done!".
+    6. Delete file hello_world.py
+
+    @@start
+    {
+        "file": "core/script.py",
+        "action": "insert",
+        "insert-after-line": 3,
+        "insert-before-line": 4
+    }
+    @@code
+        if name == "Bob":
+            print("Nice to see you again!")
+    @@end
+    @@start
+    {
+        "file": "core/utils.py",
+        "action": "create-file"
+    }
+    @@code
+    def get_name():
+        return input("Enter your name: ")
+    @@end
+    @@start
+    {
+        "file": "core/script.py",
+        "action": "insert",
+        "insert-after-line": 0,
+        "insert-before-line": 1
+    }
+    @@code
+    from core.utils import get_name
+    @@end
+    @@start
+    {
+        "file": "core/script.py",
+        "action": "replace",
+        "start-line": 10,
+        "end-line": 10
+    }
+    @@code
+    def main():
+        name = get_name()
+    @@end
+    @@start
+    {
+        "file": "core/script.py",
+        "action": "delete",
+        "start-line": 13,
+        "end-line": 13
+    }
+    @@end
+    @@start
+    {
+        "file": "core/hello_world.py",
+        "action": "delete-file",
+    }
+    @@end
+"""
+
+system_prompt = "\n\n" + "\n".join([system_prompt_prefix, system_prompt_example])

--- a/mentat/prompts.py
+++ b/mentat/prompts.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 system_prompt_prefix = """
     You are part of an automated coding system. As such, responses must adhere
     strictly to the required format, so they can be parsed programmaticaly. 
@@ -40,8 +42,7 @@ system_prompt_prefix = """
     (only the high-level code map), tell the user which files you need the source code
     for so you can make edits correctly.
 """
-system_prompt_prefix = system_prompt_prefix.strip()
-system_prompt_prefix = "\n".join(l.strip() for l in system_prompt_prefix.splitlines())
+system_prompt_prefix = dedent(system_prompt_prefix).strip()
 
 system_prompt_example = """
     Example 1:
@@ -198,5 +199,6 @@ system_prompt_example = """
     }
     @@end
 """
+system_prompt_example = dedent(system_prompt_example).strip()
 
 system_prompt = "\n\n" + "\n".join([system_prompt_prefix, system_prompt_example])

--- a/mentat/prompts.py
+++ b/mentat/prompts.py
@@ -1,9 +1,23 @@
 from textwrap import dedent
 
 system_prompt = """
-    You are part of an automated coding system. As such, responses must adhere strictly to the required format, so they can be parsed programmaticaly. Your input will consist of a user request, the contents of code files, and sometimes the git diff of current code files. The request may be to add a new feature, update the code, fix a bug, add comments or docstrings, etc.
-    The first part of your response should contain an brief summary of the changes you plan to make, then a list of the changes. Ensure you plan ahead, like planning to add imports for things you need to use in your changes, etc. The second part of your response will be the changes in the required edit format. Code edits consist of either inserts, deletes, replacements, creating new files, or deleting existing files. They can be of multiple lines of code. Edit description blocks start with @@start and end with @@end. If the edit is a delete or delete-file, then the block should only contain a JSON formatted section. In insert, replace, and create-file blocks, there must be a second section containing the new line or lines of code. The JSON section and code section are separated by a line containing just @@code.
-    If the request requires clarification or the user is asking for something other than code changes, such as design ideas, don't return any edit description blocks.
+    You are part of an automated coding system. As such, responses must adhere strictly
+    to the required format, so they can be parsed programmaticaly. Your input will
+    consist of a user request, the contents of code files, and sometimes the git diff of
+    current code files. The request may be to add a new feature, update the code, fix a
+    bug, add comments or docstrings, etc. The first part of your response should contain
+    an brief summary of the changes you plan to make, then a list of the changes. Ensure
+    you plan ahead, like planning to add imports for things you need to use in your
+    changes, etc. The second part of your response will be the changes in the required
+    edit format. Code edits consist of either inserts, deletes, replacements, creating
+    new files, or deleting existing files. They can be of multiple lines of code. Edit
+    description blocks start with @@start and end with @@end. If the edit is a delete 
+    or delete-file, then the block should only contain a JSON formatted section. In
+    insert, replace, and create-file blocks, there must be a second section containing
+    the new line or lines of code. The JSON section and code section are separated by
+    a line containing just @@code. If the request requires clarification or the user is
+    asking for something other than code changes, such as design ideas, don't return 
+    any edit description blocks.
 
 
     Example 1:

--- a/mentat/prompts.py
+++ b/mentat/prompts.py
@@ -1,91 +1,14 @@
 from textwrap import dedent
 
-system_prompt_prefix = """
-    You are part of an automated coding system. As such, responses must adhere
-    strictly to the required format, so they can be parsed programmaticaly. 
+system_prompt = """
+    You are part of an automated coding system. As such, responses must adhere strictly to the required format, so they can be parsed programmaticaly. Your input will consist of a user request, the contents of code files, and sometimes the git diff of current code files. The request may be to add a new feature, update the code, fix a bug, add comments or docstrings, etc.
+    The first part of your response should contain an brief summary of the changes you plan to make, then a list of the changes. Ensure you plan ahead, like planning to add imports for things you need to use in your changes, etc. The second part of your response will be the changes in the required edit format. Code edits consist of either inserts, deletes, replacements, creating new files, or deleting existing files. They can be of multiple lines of code. Edit description blocks start with @@start and end with @@end. If the edit is a delete or delete-file, then the block should only contain a JSON formatted section. In insert, replace, and create-file blocks, there must be a second section containing the new line or lines of code. The JSON section and code section are separated by a line containing just @@code.
+    If the request requires clarification or the user is asking for something other than code changes, such as design ideas, don't return any edit description blocks.
 
-    Your input will consist of:
-        - a user request
-        - the contents of code files
-        - sometimes high-level, read-only tree of file paths and their contents
-        - sometimes the git diff of current code files
 
-    The user request may be to add a new feature, update the code, fix a
-    bug, add comments or docstrings, etc. DO NOT suggest edits or try to add/edit/delete
-    code for files that you are missing under "Code Files" but do exist in "Code Map".
-
-    DO NOT SUGGEST EDITS TO FILES THAT ARE NOT ADDED UNDER "CODE FILES".
-    
-    Your response should be one of the following:
-    
-    1. If you have the code in "Code Files" to make edits:
-    
-    The first part of your response should contain an brief summary of the changes
-    you plan to make, then a list of the changes. Ensure you plan ahead, like 
-    planning to add imports for things you need to use in your changes, etc.
-    The second part of your response will be the changes in the required
-    edit format. Code edits consist of either inserts, deletes, replacements,
-    creating new files, or deleting existing files. They can be of multiple
-    lines of code. Edit description blocks start with @@start and end with @@end.
-    If the edit is a delete or delete-file, then the block should only contain a
-    JSON formatted section. In insert, replace, and create-file blocks, there
-    must be a second section containing the new line or lines of code.
-    The JSON section and code section are separated by a line containing just
-    @@code.
-    If the request requires clarification or the user is asking for something
-    other than code changes, such as design ideas, don't return any edit
-    description blocks.
-
-    2. If you're missing code files in "Code Files" that you need to edit: 
-
-    If you need to make changes to files that you don't have the full source code of 
-    (only the high-level code map), tell the user which files you need the source code
-    for so you can make edits correctly.
-"""
-system_prompt_prefix = dedent(system_prompt_prefix).strip()
-
-system_prompt_example = """
     Example 1:
-    
-    Here is an example response to a user request where the user is requesting changes to
-    a function that isn't in "Code Files", but is in "Code Map":
 
-    Code Files:
-
-    core/hello_world.py
-    1:
-    2:def hello_world():
-    3:    print("Hello, World!")
-    4:
-
-    User Request:
-    Edit the say_goodbye function and make the response be "See ya!" 
-
-    Code Map:
-
-    .gitignore
-
-    core/hello_world.py
-            function
-                    hello_world ()
-
-    core/script.py
-            function
-                    main (name)
-                    say_goodbye ()
-                    say_hello (name)
-
-    Example Response:
-
-    It looks like you're requesting edits to a function called `say_goodbye` which is
-    in the `core/script.py` file. Please add this file into "Code Files" as I need the 
-    full code of `say_goodbye`.
-
-
-    Example 2:
-
-    Here is an example response to a user request where you have all of the needed files
-    added under "Code Files" to make edits:
+    To demonstrate the response format, here's an example user request, followed by an example response:
 
     Code Files:
 
@@ -111,12 +34,6 @@ system_prompt_example = """
     3:    print("Hello, World!")
     4:
 
-    User Request:
-    After saying hello, if the user's name is "Bob", say "Nice to see you again!" on another line.
-    Add a function to get the user's name and use it in main instead of taking name as an argument.
-    The new function should be in a separate file called utils.py. Stop saying "Done!". Finally,
-    delete the hello_world.py file.
-
     Code Map:
 
     .gitignore
@@ -130,6 +47,13 @@ system_prompt_example = """
                     main (name)
                     say_goodbye ()
                     say_hello (name)
+
+    User Request:
+    After saying hello, if the user's name is "Bob", say "Nice to see you again!" on another line.
+    Add a function to get the user's name and use it in main instead of taking name as an argument.
+    The new function should be in a separate file called utils.py. Stop saying "Done!". Finally,
+    delete the hello_world.py file.
+
 
     Example Response:
 
@@ -198,7 +122,66 @@ system_prompt_example = """
         "action": "delete-file",
     }
     @@end
-"""
-system_prompt_example = dedent(system_prompt_example).strip()
 
-system_prompt = "\n\n" + "\n".join([system_prompt_prefix, system_prompt_example])
+
+    Example 2:
+
+    Here's an example response to a user request where the user is requesting changes to
+    a function that is in "Code Files", but they want to use a function that needs to be 
+    imported from a file in "Code Map":
+
+    Code Files:
+
+    core/hello_world.py
+    1:
+    2:def hello_world():
+    3:    print("Hello, World!")
+    4:
+
+    Code Map:
+
+    .gitignore
+
+    core/hello_world.py
+            function
+                    hello_world ()
+
+    core/script.py
+            function
+                    main (name)
+                    say_goodbye ()
+                    say_hello (name)
+
+    User Request:
+    Call say_goodbye after printing hello world
+
+    Example Response:
+
+    I will make the modifications to hello_world.py
+
+    Steps:
+    1. Import the say_goodbye function in hello_world.py
+    2. Modify hello_world.py, adding a function call for say_goodbye
+
+    @@start
+    {
+        "file": "core/hello_world.py",
+        "action": "insert",
+        "insert-after-line": 0,
+        "insert-before-line": 1
+    }
+    @@code
+    from core.script import say_goodbye
+    @@end
+    @@start
+    {
+        "file": "core/hello_world.py",
+        "action": "insert",
+        "insert-after-line": 4,
+        "insert-before-line": 5
+    }
+    @@code
+        say_goodbye()
+    @@end
+"""
+system_prompt = dedent(system_prompt).strip()

--- a/testbed/scripts/echo.py
+++ b/testbed/scripts/echo.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+
+def echo(value: Any) -> Any:
+    return value
+
+
+def echo_hardcoded():
+    return "00mp94!2PgK%i2h@m&5Xzk4T&VqC*NWQ^mp94!2PgK%i2h@m&5Xzk4T&VqC*NWQ^"

--- a/tests/benchmark_test.py
+++ b/tests/benchmark_test.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+from textwrap import dedent
 
 import pytest
 
@@ -130,4 +131,24 @@ def test_start_project_from_scratch(mock_collect_user_input):
 
     result = subprocess.run(["python", fizzbuzz_path], capture_output=True, text=True)
     expected_output = "1\n2\nFizz\n4\nBuzz\nFizz\n7\n8\nFizz\nBuzz\n"
+    assert result.stdout.strip() == expected_output.strip()
+
+
+def test_import_from_code_map(mock_collect_user_input):
+    prompt = """
+        make a file that gets the base64 encoded value of echo_hardcoded, named 
+        encoded_echo.py, and print the encoded value as a string
+    """
+    prompt = dedent(prompt).strip()
+
+    mock_collect_user_input.side_effect = [prompt, "y", KeyboardInterrupt]
+    run([])
+
+    encoded_echo_path = "encoded_echo.py"
+    assert os.path.exists(encoded_echo_path)
+
+    result = subprocess.run(
+        ["python", encoded_echo_path], capture_output=True, text=True
+    )
+    expected_output = "MDBtcDk0ITJQZ0slaTJoQG0mNVh6azRUJlZxQypOV1FebXA5NCEyUGdLJWkyaEBtJjVYems0VCZWcUMqTldRXg=="
     assert result.stdout.strip() == expected_output.strip()


### PR DESCRIPTION
### Summary
This PR adds a high-level code map generated from [ctags](https://github.com/universal-ctags/ctags) into the system prompt which gives the model more context on what other code/classes/methods/etc. it can use that haven't been directly added into the model context by the user. 

This implementation takes inspiration from how [Aider](https://github.com/paul-gauthier/aider) works with large codebases. [Here's a writeup](https://aider.chat/docs/ctags.html) from the author of Aider on how it works.

### Why this is needed
This work is a prerequisite for having Mentat automatically add new source code from files outside the context.

### To-Do
Need to finish these before this PR is ready for review:
- [x] create a 'minified' code map that fits into the model context if the full code map is too large] 
- [ ] ~~prevent mentat from suggesting edits for files which exist in the code map outside the model context]~~
- [x] add a token limit to the code map, filter out less relevant ctags/files as needed
- [x] update test cases 
- [x] handle user not having ctags installed 

### Prior to Merge
- [x] @biobootloader: run benchmarks with and without, to determine if system prompt changes degrade performance on other tasks.