### PR TITLE
Fix git root parsing when using msys2 git on Windows

### DIFF
--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -61,6 +61,8 @@ def _get_git_root_for_path(path) -> str:
             .decode("utf-8")
             .strip()
         )
+        # --show-toplevel doesn't work in some windows environment with posix paths,
+        # like msys2, so we have to use --show-prefix instead
         git_root = os.path.abspath(
             os.path.join(dir_path, "../" * len(Path(relative_path).parts))
         )

--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -48,12 +48,12 @@ def _get_git_root_for_path(path) -> str:
     else:
         dir_path = os.path.dirname(path)
     try:
-        git_root = (
+        relative_path = (
             subprocess.check_output(
                 [
                     "git",
                     "rev-parse",
-                    "--show-toplevel",
+                    "--show-prefix",
                 ],
                 cwd=os.path.realpath(dir_path),
                 stderr=subprocess.DEVNULL,
@@ -61,6 +61,7 @@ def _get_git_root_for_path(path) -> str:
             .decode("utf-8")
             .strip()
         )
+        git_root = os.path.abspath(os.path.join(dir_path, "../" * (len(os.path.split(relative_path)) - 1)))
         # call realpath to resolve symlinks, so all paths match
         return os.path.realpath(git_root)
     except subprocess.CalledProcessError:

--- a/mentat/git_handler.py
+++ b/mentat/git_handler.py
@@ -61,7 +61,9 @@ def _get_git_root_for_path(path) -> str:
             .decode("utf-8")
             .strip()
         )
-        git_root = os.path.abspath(os.path.join(dir_path, "../" * (len(os.path.split(relative_path)) - 1)))
+        git_root = os.path.abspath(
+            os.path.join(dir_path, "../" * len(Path(relative_path).parts))
+        )
         # call realpath to resolve symlinks, so all paths match
         return os.path.realpath(git_root)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
Currently, mentat won't work with a msys2-installed Git on Windows because when executing `git rev-parse --show-toplevel`, it will produce a non-compatible path (e.g. /c/Users/xxx/mentat).
According to [Msys2](https://www.msys2.org/docs/git/), they suggest to use `git rev-parse --show-prefix`, which outputs a relative path from the root to the current working directory and it is both a valid Unix and Windows path.
So I modified the related code, and it works fine for my setup.