### PR TITLE
Partial files allowed

### DIFF
--- a/mentat/app.py
+++ b/mentat/app.py
@@ -49,7 +49,7 @@ def run_cli():
     no_code_map = args.no_code_map
     # Expanding paths as soon as possible because some shells such as zsh automatically
     # expand globs and we want to avoid differences in functionality between shells
-    run(expand_paths(paths), expand_paths(exclude_paths))
+    run(expand_paths(paths), expand_paths(exclude_paths), no_code_map)
 
 
 def expand_paths(paths: Iterable[str]) -> Iterable[str]:

--- a/mentat/app.py
+++ b/mentat/app.py
@@ -1,5 +1,4 @@
 import argparse
-import glob
 import logging
 from typing import Iterable, Optional
 

--- a/mentat/app.py
+++ b/mentat/app.py
@@ -37,26 +37,7 @@ def run_cli():
     args = parser.parse_args()
     paths = args.paths
     exclude_paths = args.exclude
-    run(expand_paths(paths), expand_paths(exclude_paths))
-
-
-def expand_paths(paths: Iterable[str]) -> Iterable[str]:
-    globbed_paths = set()
-    invalid_paths = []
-    for path in paths:
-        new_paths = glob.glob(pathname=path, recursive=True)
-        if new_paths:
-            globbed_paths.update(new_paths)
-        else:
-            invalid_paths.append(path)
-    if invalid_paths:
-        cprint(
-            "The following paths do not exist:",
-            "light_yellow",
-        )
-        print("\n".join(invalid_paths))
-        exit()
-    return globbed_paths
+    run(paths, exclude_paths)
 
 
 def run(paths: Iterable[str], exclude_paths: Optional[Iterable[str]] = None):

--- a/mentat/app.py
+++ b/mentat/app.py
@@ -1,6 +1,7 @@
 import argparse
 import glob
 import logging
+from pathlib import Path
 from typing import Iterable, Optional
 
 from termcolor import cprint

--- a/mentat/code_file.py
+++ b/mentat/code_file.py
@@ -1,0 +1,48 @@
+import math
+from pathlib import Path
+
+
+class Interval:
+    def __init__(
+        self,
+        start: int,
+        end: int,
+    ):
+        self.start = start
+        self.end = end
+
+    def contains(self, k):
+        return self.start <= k <= self.end
+
+
+def parse_intervals(interval_string: str) -> list[Interval] | None:
+    try:
+        intervals = []
+        for interval in interval_string.split(","):
+            interval = interval.split("-", 1)
+            if len(interval) == 1:
+                intervals += [Interval(int(interval[0]), int(interval[0]))]
+            else:
+                intervals += [Interval(int(interval[0]), int(interval[1]))]
+        return intervals
+    except (ValueError, IndexError):
+        return None
+
+
+class CodeFile:
+    def __init__(self, path: str | Path):
+        if Path(path).exists():
+            self.path = Path(path)
+            self.intervals = [Interval(0, math.inf)]
+        else:
+            path = str(path)
+            split = path.rsplit(":", 1)
+            self.path = Path(split[0])
+            if not self.path.exists():
+                self.path = Path(path)
+                self.intervals = [Interval(0, math.inf)]
+            else:
+                self.intervals = parse_intervals(split[1])
+
+    def contains_line(self, line_number: int):
+        return any([interval.contains(line_number) for interval in self.intervals])

--- a/mentat/code_file.py
+++ b/mentat/code_file.py
@@ -30,6 +30,16 @@ def parse_intervals(interval_string: str) -> list[Interval] | None:
 
 
 class CodeFile:
+    """
+    Represents a file along with the lines that should be in the prompt context. Can be
+    iniitialized with a Path object or a string path with optional line information
+    such as "path/to/file.py:1-5,7,12-40".
+
+    Attributes:
+        path: The path to the file.
+        intervals: The lines in context.
+    """
+
     def __init__(self, path: str | Path):
         if Path(path).exists():
             self.path = Path(path)

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -1,9 +1,11 @@
 import os
+from textwrap import dedent
 from unittest import TestCase
 
 import pytest
 
-from mentat.code_file_manager import CodeFileManager, expand_paths
+from mentat.app import expand_paths
+from mentat.code_file_manager import CodeFileManager
 from mentat.config_manager import ConfigManager
 from mentat.errors import UserError
 
@@ -72,7 +74,6 @@ def test_config_glob_exclude(mocker, temp_testbed, mock_config):
         git_root=temp_testbed,
     )
     file_paths = [str(file.path.resolve()) for file in code_file_manager.files]
-    print("jake here", file_paths)
     assert os.path.join(temp_testbed, glob_exclude_path) not in file_paths
     assert os.path.join(temp_testbed, glob_include_path) in file_paths
     assert os.path.join(temp_testbed, directly_added_glob_excluded_path) in file_paths
@@ -194,13 +195,12 @@ def test_partial_files(temp_testbed, mock_config):
     file_path = os.path.join(dir_name, file_name)
     os.makedirs(dir_name, exist_ok=True)
     with open(file_path, "w") as file_file:
-        file_file.write(
-            """I am a file
-with 5 lines
-third
-fourth
-fifth"""
-        )
+        file_file.write(dedent("""\
+             I am a file
+             with 5 lines
+             third
+             fourth
+             fifth"""))
     file_path_partial = file_path + ":1,3-5"
 
     code_file_manager = CodeFileManager(
@@ -211,14 +211,12 @@ fifth"""
         git_root=temp_testbed,
     )
     code_message = code_file_manager.get_code_message()
-    assert (
-        code_message
-        == """Code Files:
+    assert code_message == dedent("""\
+             Code Files:
 
-dir/file.txt
-1:I am a file
-3:third
-4:fourth
-5:fifth
-"""
-    )
+             dir/file.txt
+             1:I am a file
+             3:third
+             4:fourth
+             5:fifth
+              """)


### PR DESCRIPTION
The user can specify a partial file with : syntax e.g. test.txt:1-2,5 will put only lines 1,2 and 5 in scope. It is checked if that file with a colon already exists. For this a File object is created in the code_file_manager which has the path and segment information bundled.

The expand function is moved from app.py to code_file_manager.py

Test with:
```
mentat README.md:6-12,16
> Replace all instance of the word mentat with test.
```