### PR TITLE
Clear prompt with ctrl-c before quitting

### DIFF
--- a/mentat/mentat_prompt_session.py
+++ b/mentat/mentat_prompt_session.py
@@ -102,3 +102,10 @@ class MentatPromptSession(PromptSession):
             suggestion = event.current_buffer.suggestion
             if suggestion:
                 event.current_buffer.insert_text(suggestion.text)
+
+        @self.bindings.add("c-c")
+        def _(event: KeyPressEvent):
+            if event.current_buffer.text != "":
+                event.current_buffer.reset()
+            else:
+                event.app.exit(result="q")


### PR DESCRIPTION
Instead of exiting immediately on ctrl-c, we clear any text that's been typed. This is pretty common behavior for other cli tools, so I added this since I keep accidentally quitting mentat sessions after trying to clear a bunch of text I just typed.