### PR TITLE
Switch package name on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/bio_bootloader?style=social)](https://twitter.com/bio_bootloader)
 [![Discord Follow](https://dcbadge.vercel.app/api/server/XbPdxAMJte?style=flat)](https://discord.gg/zbvd9qx9Pb)
-[![Stable Version](https://img.shields.io/pypi/v/mentat-ai?color=blue)](https://pypi.org/project/mentat-ai/)
-[![License](https://img.shields.io/pypi/l/mentat-ai.svg)](https://github.com/biobootloader/mentat/blob/main/LICENSE)
+[![Stable Version](https://img.shields.io/pypi/v/mentat?color=blue)](https://pypi.org/project/mentat/)
+[![License](https://img.shields.io/pypi/l/mentat.svg)](https://github.com/biobootloader/mentat/blob/main/LICENSE)
 
 # 🧙‍♂️ Mentat ⚡
 
@@ -45,7 +45,7 @@ source .venv/bin/activate
 Note that you'll have to have activated the virtual environment to run mentat if you install it there.
 
 There are then 3 install methods. The first two will just let you run it:
-- PyPI: `python -m pip install mentat-ai`
+- PyPI: `python -m pip install mentat`
 - Github: `python -m pip install git+https://github.com/biobootloader/mentat.git`
 
 The third option is useful if you'd also like to modify Mentat's code, as well as run it:

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ with open(readme_path, "r", encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name="mentat-ai",
-    version="0.1.12",
+    name="mentat",
+    version="0.1.13",
     python_requires=">=3.10",
     packages=find_packages(),
     install_requires=read_requirements("requirements.txt"),

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(readme_path, "r", encoding="utf-8") as f:
 
 setup(
     name="mentat",
-    version="0.1.13",
+    version="0.1.14",
     python_requires=">=3.10",
     packages=find_packages(),
     install_requires=read_requirements("requirements.txt"),

--- a/tests/license_check.py
+++ b/tests/license_check.py
@@ -4,7 +4,7 @@ import subprocess
 import fire
 
 library_exceptions = [
-    "mentat-ai",
+    "mentat",
     # pip-licenses shows tiktoken's full license text, but it is MIT
     "tiktoken",
 ]


### PR DESCRIPTION
Thanks to the very helpful previous owner of "mentat" on PyPI, I now have control of it and we don't need to use "mentat-ai" on PyPI anymore. Should help reduce confusion!

The original package did had releases with version numbers `1.0.0` and `1.0.1`, I have "yanked" those releases (and we'll have to skip those). There is also the option to delete them. These are old and I'm sure no one depends on them so maybe that's best.

<img width="857" alt="image" src="https://github.com/biobootloader/mentat/assets/128252497/c0ad71e0-bb06-46f1-9293-3069645f26ca">
