### PR TITLE
Refactor context

### DIFF
--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -113,11 +113,9 @@ class CodeMapMessage:
 
 
 class CodeMap:
-    def __init__(
-        self, git_root: Path, config: ConfigManager, token_limit: int | None = None
-    ):
-        self.git_root = git_root
+    def __init__(self, config: ConfigManager, token_limit: int | None = None):
         self.config = config
+        self.git_root = self.config.git_root
         self.token_limit = token_limit
 
         self.ctags_disabled = True

--- a/mentat/conversation.py
+++ b/mentat/conversation.py
@@ -2,7 +2,6 @@ from termcolor import cprint
 
 from .code_change import CodeChange
 from .code_file_manager import CodeFileManager
-from .code_map import CodeMap
 from .config_manager import ConfigManager, user_config_path
 from .llm_api import (
     CostTracker,
@@ -21,13 +20,11 @@ class Conversation:
         config: ConfigManager,
         cost_tracker: CostTracker,
         code_file_manager: CodeFileManager,
-        code_map: CodeMap | None = None,
     ):
         self.messages = list[dict[str, str]]()
         self.add_system_message(system_prompt)
         self.cost_tracker = cost_tracker
         self.code_file_manager = code_file_manager
-        self.code_map = code_map
         self.model = config.model()
         if not is_model_available(self.model):
             raise KeyboardInterrupt(
@@ -49,38 +46,38 @@ class Conversation:
                 )
 
         tokens = count_tokens(
-            code_file_manager.get_code_message(), self.model
+            code_file_manager.get_code_message(self.model), self.model
         ) + count_tokens(system_prompt, self.model)
 
-        self.context_size = model_context_size(self.model)
+        context_size = model_context_size(self.model)
         maximum_context = config.maximum_context()
         if maximum_context:
-            if self.context_size:
-                self.context_size = min(self.context_size, maximum_context)
+            if context_size:
+                context_size = min(context_size, maximum_context)
             else:
-                self.context_size = maximum_context
+                context_size = maximum_context
 
-        if not self.context_size:
+        if not context_size:
             raise KeyboardInterrupt(
                 f"Context size for {self.model} is not known. Please set"
                 f" maximum-context in {user_config_path}."
             )
-        if self.context_size and tokens > self.context_size:
+        if context_size and tokens > context_size:
             raise KeyboardInterrupt(
                 f"Included files already exceed token limit ({tokens} /"
-                f" {self.context_size}). Please try running again with a reduced"
+                f" {context_size}). Please try running again with a reduced"
                 " number of files."
             )
-        elif tokens + 1000 > self.context_size:
+        elif tokens + 1000 > context_size:
             cprint(
                 f"Warning: Included files are close to token limit ({tokens} /"
-                f" {self.context_size}), you may not be able to have a long"
+                f" {context_size}), you may not be able to have a long"
                 " conversation.",
                 "red",
             )
         else:
             cprint(
-                f"File and prompt token count: {tokens} / {self.context_size}",
+                f"File and prompt token count: {tokens} / {context_size}",
                 "cyan",
             )
 
@@ -93,57 +90,11 @@ class Conversation:
     def add_assistant_message(self, message: str):
         self.messages.append({"role": "assistant", "content": message})
 
-    def get_model_response(self, config: ConfigManager) -> tuple[str, list[CodeChange]]:
+    def get_model_response(self) -> tuple[str, list[CodeChange]]:
         messages = self.messages.copy()
+        code_message = self.code_file_manager.get_code_message(self.model)
 
-        code_message = self.code_file_manager.get_code_message()
-        system_message = code_message
-
-        if self.code_map:
-            system_message_token_count = count_tokens(system_message, self.model)
-            messages_token_count = 0
-            for message in messages:
-                messages_token_count += count_tokens(message["content"], self.model)
-            token_buffer = 1000
-            token_count = (
-                system_message_token_count + messages_token_count + token_buffer
-            )
-
-            if self.context_size:
-                max_tokens_for_code_map = self.context_size - token_count
-                if self.code_map.token_limit:
-                    code_map_message_token_limit = min(
-                        self.code_map.token_limit, max_tokens_for_code_map
-                    )
-                else:
-                    code_map_message_token_limit = max_tokens_for_code_map
-            else:
-                code_map_message_token_limit = self.code_map.token_limit
-
-            code_map_message = self.code_map.get_message(
-                token_limit=code_map_message_token_limit
-            )
-            if code_map_message:
-                match (code_map_message.level):
-                    case "signatures":
-                        cprint_message_level = "full syntax tree"
-                    case "no_signatures":
-                        cprint_message_level = "partial syntax tree"
-                    case "filenames":
-                        cprint_message_level = "filepaths only"
-
-                cprint_message = f"\nIncluding CodeMap ({cprint_message_level})"
-                cprint(cprint_message, color="green")
-                system_message += f"\n{code_map_message}"
-            else:
-                cprint_message = [
-                    "\nExcluding CodeMap from system message.",
-                    "Reason: not enough tokens available in model context.",
-                ]
-                cprint_message = "\n".join(cprint_message)
-                cprint(cprint_message, color="yellow")
-
-        messages.append({"role": "system", "content": system_message})
+        messages.append({"role": "system", "content": code_message})
 
         num_prompt_tokens = get_prompt_token_count(messages, self.model)
 

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -4,7 +4,6 @@ from textwrap import dedent
 from mentat.app import run
 from mentat.code_context import CodeContext
 from mentat.code_file_manager import CodeFileManager
-from mentat.diff_context import get_diff_context
 from mentat.user_input_manager import UserInputManager
 
 
@@ -16,9 +15,6 @@ def test_posix_paths(mock_config):
     os.makedirs(dir_name, exist_ok=True)
     with open(file_path, "w") as file_file:
         file_file.write("I am a file")
-    diff_context = get_diff_context(
-        config=mock_config,
-    )
     code_context = CodeContext(
         config=mock_config,
         paths=[file_path],
@@ -30,9 +26,8 @@ def test_posix_paths(mock_config):
         ),
         config=mock_config,
         code_context=code_context,
-        diff_context=diff_context,
     )
-    code_message = code_file_manager.get_code_message()
+    code_message = code_file_manager.get_code_message(mock_config.model())
     assert dir_name + "/" + file_name in code_message.split("\n")
 
 
@@ -50,13 +45,11 @@ def test_partial_files(mock_config):
              fifth"""))
     file_path_partial = file_path + ":1,3-5"
 
-    diff_context = get_diff_context(
-        config=mock_config,
-    )
     code_context = CodeContext(
         config=mock_config,
         paths=[file_path_partial],
         exclude_paths=[],
+        no_code_map=True,
     )
     code_file_manager = CodeFileManager(
         user_input_manager=UserInputManager(
@@ -64,9 +57,8 @@ def test_partial_files(mock_config):
         ),
         config=mock_config,
         code_context=code_context,
-        diff_context=diff_context,
     )
-    code_message = code_file_manager.get_code_message()
+    code_message = code_file_manager.get_code_message(mock_config.model())
     assert code_message == dedent("""\
             Code Files:
 


### PR DESCRIPTION
This is a small PR building on #86 which moves the CodeMap and DiffContext from `code_file_manager` to `code_context`. 

The next steps (in separate PRs) will be
- Refactor CodeFile to handle read/write ops
- Streamline the context-generating process inside CodeContext
- Add Embeddings