### PR TITLE
remove logging from test environment

### DIFF
--- a/mentat/llm_api.py
+++ b/mentat/llm_api.py
@@ -39,14 +39,19 @@ def setup_api_key():
         raise UserError(f"OpenAI gave an Authentication Error:\n{e}")
 
 
-async def call_llm_api(
-    messages: list[dict[str, str]], model: str
-) -> AsyncGenerator[Any, None]:
-    if (
+def is_test_environment():
+    """Returns True if in pytest and not benchmarks"""
+    return (
         "PYTEST_CURRENT_TEST" in os.environ
         and "--benchmark" not in sys.argv
         and os.getenv("MENTAT_BENCHMARKS_RUNNING") == "false"
-    ):
+    )
+
+
+async def call_llm_api(
+    messages: list[dict[str, str]], model: str
+) -> AsyncGenerator[Any, None]:
+    if is_test_environment():
         logging.critical("OpenAI call attempted in non benchmark test environment!")
         raise MentatError("OpenAI call attempted in non benchmark test environment!")
 

--- a/mentat/logging_config.py
+++ b/mentat/logging_config.py
@@ -1,15 +1,16 @@
 import datetime
 import logging
 import logging.handlers
-import os
+
+from mentat.llm_api import is_test_environment
 
 from .config_manager import mentat_dir_path
 
 
 def setup_logging():
     logs_dir = "logs"
-    if "PYTEST_CURRENT_TEST" in os.environ:
-        logs_dir += "/test_logs"
+    if is_test_environment():
+        return
     logs_path = mentat_dir_path / logs_dir
 
     logging.getLogger("openai").setLevel(logging.WARNING)

--- a/tests/benchmarks/exercism_practice_python.py
+++ b/tests/benchmarks/exercism_practice_python.py
@@ -13,6 +13,8 @@ from mentat.user_input_manager import UserInputManager, UserQuitInterrupt
 
 threadLocal = threading.local()
 
+pytestmark = pytest.mark.benchmark
+
 
 def exercise_passed():
     try:


### PR DESCRIPTION
Removes logs from test environment, but not from benchmarks. We could also put benchmark logs in a subdirectory "benchmark_logs" instead of having them all in one directory; what do you think?