### PR TITLE
Context tree

### DIFF
--- a/mentat/app.py
+++ b/mentat/app.py
@@ -147,10 +147,10 @@ def loop(
     code_context = CodeContext(
         config, paths, exclude_paths or [], diff, pr_diff, no_code_map
     )
-    code_context.display_context()
     user_input_manager = UserInputManager(config, code_context)
     code_file_manager = CodeFileManager(user_input_manager, config, code_context)
     conv = Conversation(parser, config, cost_tracker, code_file_manager)
+    code_context.display_context()
 
     cprint("Type 'q' or use Ctrl-C to quit at any time.\n", color="cyan")
     cprint("What can I do for you?", color="light_blue")

--- a/mentat/code_context.py
+++ b/mentat/code_context.py
@@ -1,140 +1,71 @@
 import glob
-import logging
-import os
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from termcolor import cprint
 
-from .code_file import CodeFile
-from .code_map import CodeMap
+from .code_map import check_ctags_executable
 from .config_manager import ConfigManager
-from .diff_context import get_diff_context
+from .context_tree import ContextNode, DirectoryNode, FileNode, get_node
+from .diff_context import DiffContext, get_diff_context
 from .errors import UserError
-from .git_handler import get_non_gitignored_files, get_paths_with_git_diffs
 
 
-def _is_file_text_encoded(file_path: Path):
+def _set_diff_annotations(root: ContextNode, diff_context: DiffContext) -> None:
+    for file in diff_context.files:
+        node = root[file]
+        if isinstance(node, FileNode) and node.node_settings.include:
+            node.set_diff_annotations(diff_context.get_diff_annotations(file))
+
+
+def _set_code_map(
+    root: ContextNode, model: str = "gpt-4", max_tokens: Optional[int] = None
+) -> None:
     try:
-        # The ultimate filetype test
-        with open(file_path) as f:
-            f.read()
-        return True
-    except UnicodeDecodeError:
-        return False
-
-
-def _abs_files_from_list(paths: list[Path], check_for_text: bool = True):
-    files_direct = set[CodeFile]()
-    file_paths_from_dirs = set[Path]()
-    for path in paths:
-        file = CodeFile(os.path.realpath(path))
-        path = Path(file.path)
-        if path.is_file():
-            if check_for_text and not _is_file_text_encoded(path):
-                logging.info(f"File path {path} is not text encoded.")
-                raise UserError(f"File path {path} is not text encoded.")
-            files_direct.add(file)
-        elif path.is_dir():
-            nonignored_files = set(
-                map(
-                    lambda f: Path(os.path.realpath(path / f)),
-                    get_non_gitignored_files(path),
-                )
-            )
-
-            file_paths_from_dirs.update(
-                filter(
-                    lambda f: (not check_for_text) or _is_file_text_encoded(f),
-                    nonignored_files,
-                )
-            )
-
-    files_from_dirs = [
-        CodeFile(os.path.realpath(path)) for path in file_paths_from_dirs
-    ]
-    return files_direct, files_from_dirs
-
-
-def _get_files(
-    config: ConfigManager, paths: list[Path], exclude_paths: list[Path]
-) -> Dict[Path, CodeFile]:
-    excluded_files_direct, excluded_files_from_dirs = _abs_files_from_list(
-        exclude_paths, check_for_text=False
-    )
-    excluded_files, excluded_files_from_dir = set(
-        map(lambda f: f.path, excluded_files_direct)
-    ), set(map(lambda f: f.path, excluded_files_from_dirs))
-
-    glob_excluded_files = set(
-        os.path.join(config.git_root, file)
-        for glob_path in config.file_exclude_glob_list()
-        # If the user puts a / at the beginning, it will try to look in root directory
-        for file in glob.glob(
-            pathname=glob_path,
-            root_dir=config.git_root,
-            recursive=True,
+        check_ctags_executable()
+    except UserError as e:
+        ctags_disabled_message = dedent(
+            f"""
+            There was an error with your universal ctags installation, disabling CodeMap.
+            Reason: {e}
+        """
         )
-    )
-    files_direct, files_from_dirs = _abs_files_from_list(paths, check_for_text=True)
+        cprint(ctags_disabled_message, color="yellow")
+        return
 
-    # config glob excluded files only apply to files added from directories
-    files_from_dirs = [
-        file
-        for file in files_from_dirs
-        if str(file.path.resolve()) not in glob_excluded_files
-    ]
-
-    files_direct.update(files_from_dirs)
-
-    files = dict[Path, CodeFile]()
-    for file in files_direct:
-        if file.path not in excluded_files | excluded_files_from_dir:
-            files[Path(os.path.realpath(file.path))] = file
-
-    return files
-
-
-def _build_path_tree(files: list[CodeFile], git_root: Path):
-    tree = dict[str, Any]()
-    for file in files:
-        path = os.path.relpath(file.path, git_root)
-        parts = Path(path).parts
-        current_level = tree
-        for part in parts:
-            if part not in current_level:
-                current_level[part] = {}
-            current_level = current_level[part]
-    return tree
-
-
-def _print_path_tree(
-    tree: dict[str, Any], changed_files: set[Path], cur_path: Path, prefix: str = ""
-):
-    keys = list(tree.keys())
-    for i, key in enumerate(sorted(keys)):
-        if i < len(keys) - 1:
-            new_prefix = prefix + "│   "
-            print(f"{prefix}├── ", end="")
-        else:
-            new_prefix = prefix + "    "
-            print(f"{prefix}└── ", end="")
-
-        cur = cur_path / key
-        star = "* " if cur in changed_files else ""
-        if tree[key]:
-            color = "blue"
-        elif star:
-            color = "green"
-        else:
-            color = None
-        cprint(f"{star}{key}", color)
-        if tree[key]:
-            _print_path_tree(tree[key], changed_files, cur, new_prefix)
+    # Try to include everything
+    root.update_settings({"code_map": True, "include_signature": True}, recursive=True)
+    context_length = root.count_tokens(model, recursive=True)
+    if not max_tokens or context_length <= max_tokens:
+        return
+    # Otherwise, find the level at which everything fits...
+    root.update_settings({"include_signature": False}, recursive=True)
+    context_length = root.count_tokens(model, recursive=True)
+    if context_length < max_tokens:
+        _update_feature = "include_signature"
+    else:
+        root.update_settings({"code_map": False}, recursive=True)
+        context_length = root.count_tokens(model, recursive=True)
+        _update_feature = "code_map"
+    # ...then add features to files one-by-one till we run out of space
+    token_budget = max_tokens - context_length
+    for node in root.iter_nodes():
+        baseline = node.count_tokens(model)
+        node.update_settings({_update_feature: True}, recursive=False)
+        adjusted = node.count_tokens(model)
+        if adjusted - baseline > token_budget:
+            node.update_settings({_update_feature: False}, recursive=False)
+            break
+        token_budget -= adjusted - baseline
 
 
 class CodeContext:
+    config: ConfigManager
+    root: DirectoryNode
+    diff_context: DiffContext
+    context_settings: dict[str, Any]
+
     def __init__(
         self,
         config: ConfigManager,
@@ -145,59 +76,146 @@ class CodeContext:
         no_code_map: bool = False,
     ):
         self.config = config
-        # Diff context
+        self.context_settings = {
+            "paths": paths,
+            "exclude_paths": exclude_paths,
+            "no_code_map": no_code_map,
+            "diff": diff,
+            "pr_diff": pr_diff,
+        }
+        # Generate file tree
+        self.root = DirectoryNode(self.config.git_root)
+        self.refresh()
+
+    def refresh(
+        self,
+        max_tokens: Optional[int] = None,
+    ) -> None:
+        """Update file tree and display settings based on configuration"""
+
+        # Check for new and changed files
+        self.root.refresh()
+
+        # Apply user settings
         try:
-            self.diff_context = get_diff_context(config, diff, pr_diff)
-            if not paths:
-                paths = self.diff_context.files
+            self.diff_context = get_diff_context(
+                self.config,
+                self.context_settings["diff"],
+                self.context_settings["pr_diff"],
+            )
+            if not self.context_settings["paths"]:
+                self.context_settings["paths"] = self.diff_context.files
         except UserError as e:
             cprint(str(e), "light_yellow")
             exit()
-        # User-specified Files
-        self.files = _get_files(self.config, paths, exclude_paths)
-        # Universal ctags
-        self.code_map = (
-            CodeMap(self.config, token_limit=2048) if not no_code_map else None
+        for path in self.context_settings["paths"]:
+            self.add_path(path)
+        for path in self.context_settings["exclude_paths"]:
+            self.remove_path(path)
+        glob_exclude_files = set(
+            Path(file)
+            for glob_path in self.config.file_exclude_glob_list()
+            # If the user puts a / at the beginning, it will try to look in root directory
+            for file in glob.glob(
+                pathname=glob_path,
+                root_dir=self.config.git_root,
+                recursive=True,
+            )
         )
-        if self.code_map is not None and self.code_map.ctags_disabled:
-            ctags_disabled_message = f"""
-                There was an error with your universal ctags installation, disabling CodeMap.
-                Reason: {self.code_map.ctags_disabled_reason}
-            """
-            ctags_disabled_message = dedent(ctags_disabled_message)
-            cprint(ctags_disabled_message, color="yellow")
+        for path in glob_exclude_files:
+            if path in self.context_settings["paths"]:
+                continue
+            self.remove_path(path)
+        _set_diff_annotations(self.root, self.diff_context)
+
+        # Validate length
+        context_length = self.root.count_tokens(self.config.model(), recursive=True)
+        if max_tokens and context_length > max_tokens:
+            raise KeyboardInterrupt(
+                f"Code context exceeds token limit ({context_length} /"
+                f" {max_tokens}). Please try running again with a reduced"
+                " number of files."
+            )
+        # Fill-in extra space with code_map, other files from diff..
+        if not self.context_settings["no_code_map"]:
+            _set_code_map(self.root, self.config.model(), max_tokens)
+
+    @property
+    def files(self) -> list[Path]:
+        return [
+            f.relative_path()
+            for f in self.root.iter_nodes(include_dirs=False)
+            if f.node_settings.include
+        ]
 
     def display_context(self):
-        if self.files:
+        included_files = [
+            f
+            for f in self.root.iter_nodes(include_dirs=False)
+            if f.node_settings.include
+        ]
+        if len(included_files) > 0:
             cprint("Files included in context:", "green")
         else:
             cprint("No files included in context.\n", "red")
             cprint("Git project: ", "green", end="")
-        cprint(self.config.git_root.name, "blue")
-        _print_path_tree(
-            _build_path_tree(list(self.files.values()), self.config.git_root),
-            get_paths_with_git_diffs(self.config.git_root),
-            self.config.git_root,
-        )
+        cprint(self.root.path.name, "blue")
+        self.root.display_context()
         print()
         self.diff_context.display_context()
+        print()
+        if self.root.node_settings.include_signature:
+            code_map_level = "full syntax tree"
+        elif self.root.node_settings.code_map:
+            code_map_level = "partial syntax tree"
+        else:
+            return
+        cprint(f"Including Code Map: {code_map_level}", "green")
 
-    def add_file(self, code_file: CodeFile):
-        if not os.path.exists(code_file.path):
-            cprint(f"File does not exist: {code_file.path}\n", "red")
-            return
-        if code_file.path in self.files:
-            cprint(f"File already in context: {code_file.path}\n", "yellow")
-            return
-        self.files[code_file.path] = code_file
-        cprint(f"File added to context: {code_file.path}\n", "green")
+    def get_code_message(self) -> str:
+        code_message = ["Code Files:\n"]
+        code_message += self.root.get_code_message(recursive=True)
+        return "\n".join(code_message)
 
-    def remove_file(self, code_file: CodeFile):
-        if not os.path.exists(code_file.path):
-            cprint(f"File does not exist: {code_file.path}\n", "red")
+    def add_path(self, path: Path | str, verbose: bool = False):
+        if isinstance(path, str):
+            path = Path(path)
+        if not path.exists():
+            if verbose:
+                cprint(f"File does not exist: {path}\n", "red")
             return
-        if code_file.path not in self.files:
-            cprint(f"File not in context: {code_file.path}\n", "yellow")
-            return
-        del self.files[code_file.path]
-        cprint(f"File removed from context: {code_file.path}\n", "green")
+        try:
+            node = self.root[path]
+            if node.node_settings.include:
+                if verbose:
+                    cprint(
+                        f"File already in context: {node.relative_path()}\n", "yellow"
+                    )
+            else:
+                node.update_settings({"include": True}, recursive=True)
+                if verbose:
+                    cprint(f"File added to context: {node.relative_path()}\n", "green")
+        except KeyError:
+            # Add an ignored file/dir to context
+            relative_path = path.resolve().relative_to(self.root.path)
+            relative_paths = [Path(p) for p in Path(relative_path).parts]
+            _cursor = self.root
+            for part in relative_paths:
+                if part not in _cursor.children:
+                    node_path = _cursor.path / part
+                    _cursor.children[part] = get_node(node_path, _cursor)
+                    if verbose:
+                        cprint(f"Added git-ignored path to context: {part}\n", "green")
+                _cursor = _cursor.children[part]
+            _cursor.update_settings({"include": True}, recursive=True)
+
+    def remove_path(self, path: Path):
+        try:
+            node = self.root[path]
+            if not node.node_settings.include:
+                cprint(f"File already included: {node.relative_path()}\n", "yellow")
+            else:
+                node.update_settings({"include": False}, recursive=True)
+                cprint(f"File excluded: {node.relative_path()}\n", "green")
+        except KeyError:
+            cprint(f"File not in context: {path}\n", "yellow")

--- a/mentat/code_file_manager.py
+++ b/mentat/code_file_manager.py
@@ -5,7 +5,7 @@ from typing import Union
 
 from termcolor import cprint
 
-from mentat.llm_api import count_tokens, model_context_size
+from mentat.context_tree.file_node import FileNode
 from mentat.parsers.file_edit import FileEdit
 
 from .code_context import CodeContext
@@ -37,88 +37,16 @@ class CodeFileManager:
             lines = f.read().split("\n")
         return lines
 
-    def _read_all_file_lines(self) -> None:
-        self.file_lines = dict[Path, list[str]]()
-        for file in self.code_context.files.values():
-            # self.file_lines is relative to git root
-            rel_path = Path(os.path.relpath(file.path, self.config.git_root))
-            self.file_lines[rel_path] = self.read_file(file)
-
-    def get_code_message(self, model: str) -> str:
-        code_message: list[str] = []
-        if self.code_context.diff_context.files:
-            code_message += [
-                "Diff References:",
-                f' "-" = {self.code_context.diff_context.name}',
-                ' "+" = Active Changes',
-                "",
-            ]
-
-        self._read_all_file_lines()
-        code_message += ["Code Files:\n"]
-        for file in self.code_context.files.values():
-            file_message: list[str] = []
-            abs_path = file.path
-            rel_path = Path(os.path.relpath(abs_path, self.config.git_root))
-
-            # We always want to give GPT posix paths
-            posix_rel_path = Path(rel_path).as_posix()
-            file_message.append(posix_rel_path)
-
-            for i, line in enumerate(self.file_lines[rel_path], start=1):
-                if file.contains_line(i):
-                    file_message.append(f"{i}:{line}")
-            file_message.append("")
-
-            if rel_path in self.code_context.diff_context.files:
-                file_message = self.code_context.diff_context.annotate_file_message(
-                    rel_path, file_message
-                )
-
-            code_message += file_message
-
-        if self.code_context.code_map is not None:
-            code_message_tokens = count_tokens("\n".join(code_message), model)
-            context_size = model_context_size(model)
-            if context_size:
-                max_tokens_for_code_map = context_size - code_message_tokens
-                if self.code_context.code_map.token_limit:
-                    code_map_message_token_limit = min(
-                        self.code_context.code_map.token_limit, max_tokens_for_code_map
-                    )
-                else:
-                    code_map_message_token_limit = max_tokens_for_code_map
-            else:
-                code_map_message_token_limit = self.code_context.code_map.token_limit
-
-            code_map_message = self.code_context.code_map.get_message(
-                token_limit=code_map_message_token_limit
-            )
-            if code_map_message:
-                match (code_map_message.level):
-                    case "signatures":
-                        cprint_message_level = "full syntax tree"
-                    case "no_signatures":
-                        cprint_message_level = "partial syntax tree"
-                    case "filenames":
-                        cprint_message_level = "filepaths only"
-
-                cprint_message = f"\nIncluding CodeMap ({cprint_message_level})"
-                cprint(cprint_message, color="green")
-                code_message += f"\n{code_map_message}"
-            else:
-                cprint_message = [
-                    "\nExcluding CodeMap from system message.",
-                    "Reason: not enough tokens available in model context.",
-                ]
-                cprint_message = "\n".join(cprint_message)
-                cprint(cprint_message, color="yellow")
-
-        return "\n".join(code_message)
+    def file_lines(self, path: Path) -> list[str]:
+        """Temporary helper func, to be handled in code_context directly by file_node"""
+        node = self.code_context.root[path]
+        if isinstance(node, FileNode):
+            return node.path.read_text().split("\n")
+        else:
+            raise MentatError(f"Path {path} is not a file")
 
     def _add_file(self, abs_path: Path):
         logging.info(f"Adding new file {abs_path} to context")
-        self.code_context.files[abs_path] = CodeFile(abs_path)
         # create any missing directories in the path
         abs_path.parent.mkdir(parents=True, exist_ok=True)
         with open(abs_path, "w") as f:
@@ -126,8 +54,6 @@ class CodeFileManager:
 
     def _delete_file(self, abs_path: Path):
         logging.info(f"Deleting file {abs_path}")
-        if abs_path in self.code_context.files:
-            del self.code_context.files[abs_path]
         abs_path.unlink()
 
     # Mainly does checks on if file is in context, file exists, file is unchanged, etc.
@@ -146,7 +72,7 @@ class CodeFileManager:
                     raise MentatError(
                         f"Attempted to edit non-existent file {file_edit.file_path}"
                     )
-                elif file_edit.file_path not in self.code_context.files:
+                elif rel_path not in self.code_context.files:
                     raise MentatError(
                         f"Attempted to edit file {file_edit.file_path} not in context"
                     )
@@ -161,7 +87,7 @@ class CodeFileManager:
                     cprint(f"Not deleting {rel_path}", "green")
 
             if not file_edit.is_creation:
-                stored_lines = self.file_lines[rel_path]
+                stored_lines = self.file_lines(rel_path)
                 if stored_lines != self.read_file(rel_path):
                     logging.info(
                         f"File '{file_edit.file_path}' changed while generating changes"

--- a/mentat/code_map.py
+++ b/mentat/code_map.py
@@ -1,18 +1,14 @@
 import json
 import subprocess
 import tempfile
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
 
 from termcolor import cprint
 
-from .config_manager import ConfigManager
-from .git_handler import get_non_gitignored_files
-from .llm_api import count_tokens
+from mentat.errors import UserError
 
 
-def _get_code_map(root: Path, file_path: Path, exclude_signatures: bool = False) -> str:
+def get_code_map(root: Path, file_path: Path, exclude_signatures: bool = False) -> str:
     # Create ctags from executable in a subprocess
     ctags_cmd_args = [
         "--extras=-F",
@@ -84,149 +80,26 @@ def _get_code_map(root: Path, file_path: Path, exclude_signatures: bool = False)
     return output
 
 
-def _get_file_map(file_paths: set[Path]) -> str:
-    tree = dict[str, Any]()
-    for file_path in file_paths:
-        parts = file_path.parts
-        node = tree
-        for part in parts:
-            if part not in node:
-                node[part] = {}
-            node = node[part]
+def check_ctags_executable():
+    try:
+        cmd = ["ctags", "--version"]
+        output = subprocess.check_output(cmd, stderr=subprocess.PIPE).decode("utf-8")
+        output = output.lower()
 
-    def tree_to_string(tree: dict[str, Any], indent: int = 0) -> str:
-        s = ""
-        sorted_keys = sorted(tree.keys())
-        for key in sorted_keys:
-            s += "\t" * indent + key + "\n"
-            s += tree_to_string(tree[key], indent + 1)
-        return s
+        cmd = " ".join(cmd)
+        if "universal ctags" not in output:
+            raise UserError(f"{cmd} does not claim to be universal ctags")
+        if "+json" not in output:
+            raise UserError(f"{cmd} does not list +json support")
 
-    file_map_tree = tree_to_string(tree)
-    return file_map_tree
+        with tempfile.TemporaryDirectory() as tempdir:
+            hello_py = Path(tempdir) / "hello.py"
+            with open(hello_py, "w", encoding="utf-8") as f:
+                f.write("def hello():\n    print('Hello, world!')\n")
+            get_code_map(Path(tempdir), hello_py)
+    except FileNotFoundError:
+        raise UserError("ctags executable not found")
+    except Exception as e:
+        raise UserError(f"error running universal-ctags: {e}")
 
-
-@dataclass
-class CodeMapMessage:
-    level: Literal["signatures", "no_signatures", "filenames"]
-    content: str
-
-
-class CodeMap:
-    def __init__(self, config: ConfigManager, token_limit: int | None = None):
-        self.config = config
-        self.git_root = self.config.git_root
-        self.token_limit = token_limit
-
-        self.ctags_disabled = True
-        self.ctags_disabled_reason = ""
-
-        self._check_ctags_executable()
-
-    def _check_ctags_executable(self):
-        try:
-            cmd = ["ctags", "--version"]
-            output = subprocess.check_output(cmd, stderr=subprocess.PIPE).decode(
-                "utf-8"
-            )
-            output = output.lower()
-
-            cmd = " ".join(cmd)
-            if "universal ctags" not in output:
-                self.ctags_disabled_reason = (
-                    f"{cmd} does not claim to be universal ctags"
-                )
-                return
-            if "+json" not in output:
-                self.ctags_disabled_reason = f"{cmd} does not list +json support"
-                return
-
-            with tempfile.TemporaryDirectory() as tempdir:
-                hello_py = Path(tempdir) / "hello.py"
-                with open(hello_py, "w", encoding="utf-8") as f:
-                    f.write("def hello():\n    print('Hello, world!')\n")
-                _get_code_map(Path(tempdir), hello_py)
-        except FileNotFoundError:
-            self.ctags_disabled_reason = "ctags executable not found"
-            return
-        except Exception as e:
-            self.ctags_disabled_reason = f"error running universal-ctags: {e}"
-            return
-
-        self.ctags_disabled = False
-
-    def _get_message_from_ctags(
-        self,
-        root: Path,
-        file_paths: set[Path],
-        exclude_signatures: bool = False,
-        token_limit: int | None = None,
-    ) -> CodeMapMessage | None:
-        token_limit = token_limit or self.token_limit
-
-        code_maps = list[str]()
-        code_maps_token_count = 0
-        for file_path in file_paths:
-            code_map = _get_code_map(
-                root, file_path, exclude_signatures=exclude_signatures
-            )
-            code_map_token_count = count_tokens(code_map, self.config.model())
-
-            if token_limit is not None and code_maps_token_count > token_limit:
-                if exclude_signatures is True:
-                    return
-                return self._get_message_from_ctags(
-                    root, file_paths, exclude_signatures=True, token_limit=token_limit
-                )
-
-            code_maps.append(code_map)
-            code_maps_token_count += code_map_token_count
-
-        message = "Code Map:" + "\n\n" + "\n".join(code_maps)
-
-        message_token_count = count_tokens(message, self.config.model())
-        if token_limit is not None and message_token_count > token_limit:
-            if exclude_signatures is True:
-                return
-            return self._get_message_from_ctags(
-                root, file_paths, exclude_signatures=True
-            )
-
-        code_map_message = CodeMapMessage(
-            level="signatures" if not exclude_signatures else "no_signatures",
-            content=message,
-        )
-
-        return code_map_message
-
-    def _get_message_from_file_map(
-        self, file_paths: set[Path], token_limit: int | None = None
-    ) -> CodeMapMessage | None:
-        file_map_tree = _get_file_map(file_paths)
-
-        message = "Code Map:" + "\n\n" + file_map_tree
-
-        message_token_count = count_tokens(message, self.config.model())
-        token_limit = token_limit or self.token_limit
-        if token_limit is not None and message_token_count > token_limit:
-            return
-
-        code_map_message = CodeMapMessage(level="filenames", content=message)
-
-        return code_map_message
-
-    def get_message(self, token_limit: int | None = None) -> CodeMapMessage | None:
-        git_file_paths = get_non_gitignored_files(self.git_root)
-
-        if not self.ctags_disabled:
-            code_map_message = self._get_message_from_ctags(
-                self.git_root, git_file_paths, token_limit=token_limit
-            )
-            if code_map_message is not None:
-                return code_map_message
-
-        file_map_message = self._get_message_from_file_map(
-            git_file_paths, token_limit=token_limit
-        )
-        if file_map_message is not None:
-            return file_map_message
+    return True

--- a/mentat/commands.py
+++ b/mentat/commands.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import List, Optional
 
 from termcolor import colored, cprint
 
 from .code_context import CodeContext
-from .code_file import CodeFile
 from .errors import MentatError
 from .git_handler import commit
 
@@ -138,8 +138,9 @@ class AddCommand(Command, command_name="add"):
             cprint("No files specified\n", "yellow")
             return
         for file_path in args:
-            code_file = CodeFile(file_path)
-            self.code_context.add_file(code_file)
+            # TODO: Handle globbing
+            _path = Path(file_path)
+            self.code_context.add_path(_path, verbose=True)
 
     @classmethod
     def argument_names(cls) -> list[str]:
@@ -159,8 +160,8 @@ class RemoveCommand(Command, command_name="remove"):
             cprint("No files specified\n", "yellow")
             return
         for file_path in args:
-            code_file = CodeFile(file_path)
-            self.code_context.remove_file(code_file)
+            _path = Path(file_path)
+            self.code_context.remove_path(_path)
 
     @classmethod
     def argument_names(cls) -> list[str]:

--- a/mentat/context_tree/__init__.py
+++ b/mentat/context_tree/__init__.py
@@ -1,0 +1,3 @@
+from .directory_node import DirectoryNode, get_node  # type: ignore
+from .file_node import FileNode  # type: ignore
+from .node import ContextNode  # type: ignore

--- a/mentat/context_tree/directory_node.py
+++ b/mentat/context_tree/directory_node.py
@@ -1,0 +1,106 @@
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from termcolor import cprint
+
+from .file_node import FileNode, is_file_text_encoded
+from .node import ContextNode
+
+
+def _has_child_with_setting(node: ContextNode, setting: str) -> bool:
+    for child in node.children.values():
+        if isinstance(child, DirectoryNode):
+            if _has_child_with_setting(child, setting):
+                return True
+        elif child.node_settings.__dict__[setting]:
+            return True
+    return False
+
+
+def get_node(path: Path, parent: Optional[ContextNode] = None) -> ContextNode:
+    """Return the ContextNode at the given path."""
+    if path.is_dir():
+        return DirectoryNode(path, parent)
+    else:
+        return FileNode(path, parent)
+
+
+class DirectoryNode(ContextNode):
+    def __init__(self, path: Path, parent: Optional[ContextNode] = None):
+        super().__init__(path, parent)
+        self.refresh()
+
+    def refresh(self):
+        # Get non-ignored git children at this level
+        _tracked: list[str] = subprocess.check_output(
+            ["git", "ls-files"], cwd=self.path, universal_newlines=True
+        ).splitlines()
+        _tracked = list({Path(child).parts[0] for child in _tracked})
+
+        # Get children not tracked by git at this level
+        _untracked: list[str] = subprocess.check_output(
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            cwd=self.path,
+            universal_newlines=True,
+        ).splitlines()
+        _untracked = list({Path(child).parts[0] for child in _untracked})
+
+        previous_paths = set(self.children.keys())
+        active_paths = set(Path(c) for c in _tracked + _untracked)
+        paths_added = sorted(active_paths - previous_paths)
+        paths_removed = previous_paths - active_paths
+        for child in paths_added:
+            child_abs = Path(self.path, child)
+            if not child_abs.is_dir() and not is_file_text_encoded(child_abs):
+                continue
+            child_path = Path(self.path, child)
+            child_node = get_node(child_path, self)
+            self.children[Path(child_node.path.name)] = child_node
+        for child in paths_removed:
+            if child.exists() and self.children[child].node_settings.include:
+                continue
+            del self.children[child]
+
+    def display_context(self, prefix: str = ""):
+        """Print directory if node_settings.text is True for any child"""
+        if not self.node_settings.include and not _has_child_with_setting(
+            self, "include"
+        ):
+            return
+
+        include_children = list[ContextNode]()
+        for child in self.children.values():
+            if child.node_settings.include:
+                include_children.append(child)
+            elif isinstance(child, DirectoryNode):
+                if _has_child_with_setting(child, "include"):
+                    include_children.append(child)
+
+        for i, child in enumerate(include_children):
+            if i < len(include_children) - 1:
+                new_prefix = prefix + "│   "
+                print(f"{prefix}├── ", end="")
+            else:
+                new_prefix = prefix + "    "
+                print(f"{prefix}└── ", end="")
+
+            star = "* " if self.node_settings.diff else ""
+            if child.path.is_dir():
+                color = "blue"
+            elif star:
+                color = "green"
+            else:
+                color = None
+            cprint(f"{star}{child.path.name}", color)
+            if child.path.is_dir():
+                child.display_context(new_prefix)
+
+    def get_code_message(self, recursive: bool = False) -> list[str]:
+        message = list[str]()
+        if _has_child_with_setting(self, "include"):
+            message += [f"{self.relative_path().as_posix()}/"]
+        if recursive:
+            for child in self.children.values():
+                message += child.get_code_message(recursive)
+        return message

--- a/mentat/context_tree/file_node.py
+++ b/mentat/context_tree/file_node.py
@@ -1,0 +1,81 @@
+import hashlib
+from pathlib import Path
+from typing import Optional
+
+from mentat.code_map import get_code_map
+from mentat.diff_context import DiffAnnotation, annotate_file_message
+from mentat.errors import MentatError, UserError
+
+from .node import ContextNode
+
+
+def is_file_text_encoded(file_path: Path):
+    try:
+        # The ultimate filetype test
+        with open(file_path) as f:
+            f.read()
+        return True
+    except UnicodeDecodeError:
+        return False
+
+
+def _compute_hash(data: str) -> str:
+    """Compute SHA-256 checksum for given data."""
+    sha256 = hashlib.sha256()
+    sha256.update(data.encode("utf-8"))
+    return sha256.hexdigest()
+
+
+class FileNode(ContextNode):
+    def __init__(self, path: Path, parent: Optional[ContextNode] = None):
+        super().__init__(path, parent)
+        self.refresh()
+
+    _hash: str = ""
+
+    def refresh(self):
+        if not is_file_text_encoded(self.path):
+            raise UserError(f"File {self.path} is not a text file.")
+        new_hash = _compute_hash(self.path.read_text())
+        if new_hash != self._hash:
+            self._hash = new_hash
+
+    _diff_annotations: list[DiffAnnotation]
+
+    def set_diff_annotations(self, diff_annotations: list[DiffAnnotation]) -> None:
+        self._diff_annotations = diff_annotations
+
+    def display_context(self, prefix: str = ""):
+        pass  # Handled by directory
+
+    def get_code_message(self, recursive: bool = False) -> list[str]:
+        message = list[str]()
+        if self.node_settings.diff and not self._diff_annotations:
+            raise MentatError(f"Diff annotations not set for file {self.path}.")
+
+        # If user-specified, Include entire code body with diff annotations
+        if self.node_settings.include:
+            message += [f"{self.relative_path().as_posix()}"]
+            code_message = self.path.read_text().splitlines()
+            if self.node_settings.diff:
+                code_message = annotate_file_message(
+                    code_message, self._diff_annotations
+                )
+            message += code_message
+            return message
+
+        # Else include diff and/or code_map
+        if self.node_settings.diff:
+            message += [f"{self.relative_path().as_posix()}"]
+            for annotation in self._diff_annotations:
+                message.append(
+                    f"{annotation.start}:{annotation.start + annotation.length}"
+                )
+                message += annotation.message
+        if self.node_settings.code_map:
+            message += get_code_map(
+                self.root().path,
+                self.relative_path(),
+                not self.node_settings.include_signature,
+            ).splitlines()
+        return message

--- a/mentat/context_tree/node.py
+++ b/mentat/context_tree/node.py
@@ -1,0 +1,102 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+from mentat.errors import MentatError
+from mentat.llm_api import count_tokens
+
+
+@dataclass
+class ContextNodeSettings:
+    # Code body
+    include: bool = False
+    diff: bool = False
+    # Code map
+    include_signature: bool = False
+    code_map: bool = False
+    file_name: bool = False
+
+
+class ContextNode:
+    path: Path  # Absolute
+    parent: Optional["ContextNode"]
+    children: dict[Path, "ContextNode"]  # Indexed by path relative to self.path
+    node_settings: ContextNodeSettings  # Controls message generation
+
+    def __init__(self, path: Path, parent: Optional["ContextNode"] = None):
+        try:
+            self.path = path.resolve()
+        except FileNotFoundError:
+            raise MentatError(f"Path {path} does not exist.")
+        self.parent = parent
+        self.children = {}
+        self.node_settings = ContextNodeSettings()
+
+    def refresh(self) -> None:
+        """Refresh node and subtree."""
+        raise NotImplementedError
+
+    #  --------------- NAVIGATION ---------------
+
+    def root(self) -> "ContextNode":
+        return self.parent.root() if self.parent else self
+
+    def relative_path(self) -> Path:
+        """Return path relative to the root ContextNode (git_root)"""
+        return self.path.relative_to(self.root().path)
+
+    def __getitem__(self, path: Path | str) -> "ContextNode":
+        """Return the ContextNode at the given relative or absolute path."""
+        if isinstance(path, str):
+            path = Path(path)
+        if path.is_absolute():
+            path = path.relative_to(self.path)
+        if len(path.parts) == 0:
+            return self
+        first, *rest = path.parts
+        first = Path(first)
+        if first in self.children:
+            if rest:
+                rest = Path(*rest)
+                return self.children[first][rest]
+            else:
+                return self.children[first]
+        else:
+            raise KeyError(f"Path {path} not found in {self.path}")
+
+    def iter_nodes(
+        self, include_dirs: bool = True, include_files: bool = True
+    ) -> Iterable["ContextNode"]:
+        """Yield all nodes in subtree depth-first."""
+        if include_dirs and self.path.is_dir():
+            yield self
+        if include_files and self.path.is_file():
+            yield self
+        for child in self.children.values():
+            yield from child.iter_nodes(include_dirs, include_files)
+
+    #  --------------- MESSAGE GENERATION ---------------
+
+    def update_settings(self, updates: dict[str, bool], recursive: bool = False):
+        for key, value in updates.items():
+            setattr(self.node_settings, key, value)
+        if recursive:
+            for child in self.children.values():
+                child.update_settings(updates, recursive)
+
+    def display_context(self, prefix: str = "") -> None:
+        """Print a summary of current context to interface."""
+        raise NotImplementedError
+
+    def get_code_message(self, recursive: bool = False) -> list[str]:
+        """Return the code message for prompt."""
+        raise NotImplementedError
+
+    def count_tokens(self, model: str = "gpt-4", recursive: bool = False) -> int:
+        """Return the number of tokens in this node's code message."""
+        code_message = self.get_code_message()
+        count = count_tokens("\n".join(code_message), model)
+        if recursive:
+            for child in self.children.values():
+                count += child.count_tokens(model, True)
+        return count

--- a/mentat/diff_context.py
+++ b/mentat/diff_context.py
@@ -52,7 +52,7 @@ def _parse_diff(diff: str) -> list[DiffAnnotation]:
     return annotations
 
 
-def _annotate_file_message(
+def annotate_file_message(
     code_message: list[str], annotations: list[DiffAnnotation]
 ) -> list[str]:
     """Return the code_message with annotations inserted."""
@@ -123,18 +123,14 @@ class DiffContext:
             num_lines += len(
                 [line for line in diff_lines if line.startswith(("+ ", "- "))]
             )
-        print(f" ─•─ {self.name} | {num_files} files | {num_lines} lines\n")
+        print(f" ─•─ {self.name} | {num_files} files | {num_lines} lines")
 
-    def annotate_file_message(
-        self, rel_path: Path, file_message: list[str]
-    ) -> list[str]:
+    def get_diff_annotations(self, rel_path: Path) -> list[DiffAnnotation]:
         """Return file_message annotated with active diff."""
-        if not self.files:
-            return file_message
-
+        if not self.files or rel_path not in self.files:
+            return []
         diff = get_diff_for_file(self.config.git_root, self.target, rel_path)
-        annotations = _parse_diff(diff)
-        return _annotate_file_message(file_message, annotations)
+        return _parse_diff(diff)
 
 
 TreeishType = Literal["commit", "branch", "relative"]

--- a/mentat/parsers/file_edit.py
+++ b/mentat/parsers/file_edit.py
@@ -81,7 +81,7 @@ class FileEdit:
             if not self.file_path.exists():
                 cprint(f"File {rel_path} does not exist, canceling all edits to file.")
                 return False
-            elif rel_path not in code_file_manager.file_lines:
+            elif rel_path not in code_file_manager.code_context.files:
                 cprint(f"File {rel_path} not in context, canceling all edits to file.")
                 return False
 
@@ -113,7 +113,7 @@ class FileEdit:
             file_lines = []
         else:
             rel_path = Path(os.path.relpath(self.file_path, config.git_root))
-            file_lines = code_file_manager.file_lines[rel_path]
+            file_lines = code_file_manager.file_lines(rel_path)
 
         if self.is_deletion:
             display_information = DisplayInformation(

--- a/mentat/parsers/original_format/original_format_change.py
+++ b/mentat/parsers/original_format/original_format_change.py
@@ -156,7 +156,7 @@ class OriginalFormatChange:
 
             rel_path = self.file
             try:
-                self.file_lines = code_file_manager.file_lines[rel_path]
+                self.file_lines = code_file_manager.file_lines(rel_path)
             except KeyError:
                 self.error = (
                     f"Model attempted to edit {rel_path}, which isn't in current"

--- a/tests/code_context_test.py
+++ b/tests/code_context_test.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from unittest import TestCase
 
 import pytest
@@ -27,7 +28,7 @@ def test_path_gitignoring(temp_testbed, mock_config):
             file.write("I am a file")
 
     # Run CodeFileManager on the git_testing_dir, and also explicitly pass in ignored_file_2.txt
-    paths = [testing_dir_path, ignored_file_path_2]
+    paths = [Path(testing_dir_path), Path(ignored_file_path_2)]
     code_context = CodeContext(config=mock_config, paths=paths, exclude_paths=[])
 
     expected_file_paths = [
@@ -65,7 +66,7 @@ def test_config_glob_exclude(mocker, temp_testbed, mock_config):
 
     code_context = CodeContext(
         config=mock_config,
-        paths=[".", directly_added_glob_excluded_path],
+        paths=[Path("."), Path(directly_added_glob_excluded_path)],
         exclude_paths=[],
     )
     file_paths = [str(file_path.resolve()) for file_path in code_context.files]

--- a/tests/code_file_manager_test.py
+++ b/tests/code_file_manager_test.py
@@ -27,7 +27,7 @@ def test_posix_paths(mock_config):
         config=mock_config,
         code_context=code_context,
     )
-    code_message = code_file_manager.get_code_message(mock_config.model())
+    code_message = code_context.get_code_message()
     assert dir_name + "/" + file_name in code_message.split("\n")
 
 
@@ -58,7 +58,7 @@ def test_partial_files(mock_config):
         config=mock_config,
         code_context=code_context,
     )
-    code_message = code_file_manager.get_code_message(mock_config.model())
+    code_message = code_context.get_code_message()
     assert code_message == dedent("""\
             Code Files:
 

--- a/tests/context_tree_test.py
+++ b/tests/context_tree_test.py
@@ -1,0 +1,202 @@
+from pathlib import Path
+
+import pytest
+
+from mentat.context_tree import ContextNode, DirectoryNode, FileNode
+
+
+@pytest.fixture
+def root(temp_testbed) -> ContextNode:
+    root_path = Path(temp_testbed)
+    root = ContextNode(root_path)
+    
+    # Add testbed children manually
+    mf_calculator = ContextNode(Path("multifile_calculator"), root)
+    root.children[Path(mf_calculator.path.name)] = mf_calculator
+    
+    init = ContextNode(Path(mf_calculator.path / "__init__.py"), mf_calculator)
+    calculator = ContextNode(Path(mf_calculator.path / "calculator.py"), mf_calculator)
+    operations = ContextNode(Path(mf_calculator.path / "operations.py"), mf_calculator)
+    mf_calculator.children[Path(init.path.name)] = init
+    mf_calculator.children[Path(calculator.path.name)] = calculator
+    mf_calculator.children[Path(operations.path.name)] = operations
+    return root
+
+
+class TestContextNode:
+    def test_context_node_init(self, temp_testbed, root: ContextNode):
+        assert root.path == Path(temp_testbed)
+        assert root.parent is None
+        assert isinstance(root.children, dict)
+        assert (not s for s in root.node_settings.__dict__.values())
+        
+
+    def test_context_node_navigation(self, root: ContextNode):
+        # Test navigation
+        operations = root.children[Path('multifile_calculator')][Path('operations.py')]
+        assert operations.root() == root
+        assert operations.relative_path() == Path("multifile_calculator/operations.py")
+        # Test __getitem__ (works with string, relative Path or absolute Path)
+        assert root['multifile_calculator/operations.py'] == operations
+        assert root[Path('multifile_calculator/operations.py')] == operations
+        assert root[Path('multifile_calculator/operations.py').resolve()] == operations
+        with pytest.raises(KeyError):
+            root['missing_file']
+        # Test iter_nodes: return subtree depth-first
+        expected = [
+            "testbed", 
+                "multifile_calculator", 
+                    "__init__.py", 
+                    "calculator.py", 
+                    "operations.py"
+        ]
+        assert [n.path.name for n in root.iter_nodes()] == expected
+        assert [n.path.name for n in root.iter_nodes(include_files=False)] == expected[:2]
+        assert [n.path.name for n in root.iter_nodes(include_dirs=False)] == expected[2:]
+
+
+    def test_context_node_message_generation(self, root: ContextNode):
+        def _included_files():
+            return [n.path.name for n in root.iter_nodes() if n.node_settings.include]
+        assert not _included_files()
+        root['multifile_calculator'].update_settings({'include': True}, recursive=False)
+        assert _included_files() == ['multifile_calculator']
+        root['multifile_calculator'].update_settings({'include': True}, recursive=True)
+        assert _included_files() == ['multifile_calculator', '__init__.py', 'calculator.py', 'operations.py']
+
+        with pytest.raises(NotImplementedError):
+            root.display_context()
+        with pytest.raises(NotImplementedError):
+            root.get_code_message()
+
+
+class TestDirectoryNode:
+    def test_directory_node_refresh(self, temp_testbed):
+        root = DirectoryNode(Path(temp_testbed))
+        # Calls refresh automatically
+        expected = [
+            'testbed', 
+                '.gitignore', 
+                '__init__.py', 
+                'multifile_calculator', 
+                    '__init__.py', 
+                    'calculator.py',
+                    'operations.py', 
+                'scripts', 
+                    'calculator.py', 
+                    'echo.py', 
+                    'graph_class.py', 
+        ]
+        assert [n.path.name for n in root.iter_nodes()] == expected
+
+        # New untracked files show up in context
+        untracked_file = Path(temp_testbed, "untracked_file.py")
+        untracked_file.write_text("print('hello')")
+        root.refresh()
+        assert root[untracked_file].path == untracked_file.resolve()
+
+        # New git-ignored files do not show up in context...
+        ignored_file = Path(temp_testbed, "ignored_file.py")
+        ignored_file.write_text("print('hello')")
+        with open(Path(temp_testbed, ".gitignore"), "a") as f:
+            f.write("\nignored_file.py")
+        root.refresh()
+        with pytest.raises(KeyError):
+            root[ignored_file]
+        # ...but if added manually, refresh leaves them alone.
+        root.children[Path("ignored_file.py")] = FileNode(ignored_file, root)
+        root[ignored_file].update_settings({'include': True})
+        root.refresh()
+        assert root[ignored_file].path == ignored_file.resolve()
+
+    def test_directory_node_display_generation(self, temp_testbed, capfd):
+        # If no paths selected, just print directory name
+        root = DirectoryNode(Path(temp_testbed))
+        root.display_context()
+        out, err = capfd.readouterr()
+        assert out.splitlines() == []
+
+        root['scripts'].update_settings({'include': True}, recursive=True)
+        root.refresh()
+        root.display_context()
+        out, err = capfd.readouterr()
+        assert out.splitlines() == [
+            "└── scripts",
+            "    ├── calculator.py",
+            "    ├── echo.py",
+            "    └── graph_class.py",
+        ]
+
+        code_message = root.get_code_message(recursive=True)
+        assert code_message[:3] == [
+            "./",
+            "scripts/",
+            "scripts/calculator.py"
+        ]
+        expected_calculator_length = len(root['scripts/calculator.py'].path.read_text().splitlines())
+        echo_index = code_message.index("scripts/echo.py")
+        assert len(code_message[3:echo_index]) == expected_calculator_length
+
+
+@pytest.fixture
+def mock_node_context(mocker):
+    # When mentat.diff_context.annotate_file_message is called, just append second arg to first
+    mock = mocker.patch("mentat.context_tree.file_node.annotate_file_message")
+    def fake_annotate_file_message(x, y):
+        return x + [_y.message for _y in y]
+    mock.side_effect = fake_annotate_file_message
+    # When get_code_map is called, return basic string
+    mocker.patch("mentat.context_tree.file_node.get_code_map").return_value = "code_map"
+    
+    
+class DummyDiffAnnotation:
+    start: int
+    length: int
+    message: list[str]
+
+
+class TestFileNode:
+    def test_file_node_refresh(self, temp_testbed):
+        # Content hash
+        node = FileNode(Path(temp_testbed, "scripts/calculator.py"))
+        initial_hash = node._hash
+        with node.path.open("a") as f:
+            f.write("print('hello')")
+        node.refresh()
+        assert node._hash != initial_hash
+
+    def test_file_node_get_code_message(self, temp_testbed, mock_node_context):
+        # Default case: not included
+        node = FileNode(Path(temp_testbed, "scripts/calculator.py"))
+        message = node.get_code_message()
+        assert message == []
+
+        # Include entire file
+        node.update_settings({'include': True})
+        message = node.get_code_message()
+        assert len(message) == 1 + len(node.path.read_text().splitlines())
+
+        # Include entire file *and* a diff
+        node.update_settings({'diff': True})
+        annot = DummyDiffAnnotation()
+        annot.start = 0
+        annot.length = 1
+        annot.message = ['hello']
+        node.set_diff_annotations([annot])
+        message = node.get_code_message()
+        assert len(message) == 1 + len(node.path.read_text().splitlines()) + 1
+        assert message[-1] == ['hello']
+
+        # Include only diff
+        node.update_settings({'include': False})
+        message = node.get_code_message()
+        assert message == [
+            '.',  # Filepath relative to root
+            '0:1',  # Affected lines
+            'hello',  # Content
+        ]
+
+        # Include 
+        node.update_settings({'code_map': True})
+        message = node.get_code_message()
+        assert message[-1] == 'code_map'

--- a/tests/diff_context_test.py
+++ b/tests/diff_context_test.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from mentat.diff_context import DiffContext, get_diff_context
+from mentat.diff_context import DiffContext, get_diff_context, annotate_file_message
 from mentat.errors import UserError
 
 rel_path = Path("multifile_calculator/operations.py")
@@ -69,7 +69,8 @@ def test_diff_context_default(mock_config, temp_testbed, git_history):
 
     # DiffContext.annotate_file_message(): modify file_message with diff
     file_message = _get_file_message(temp_testbed)
-    annotated_message = diff_context.annotate_file_message(rel_path, file_message)
+    annotations = diff_context.get_diff_annotations(rel_path)
+    annotated_message = annotate_file_message(file_message, annotations)
     expected = file_message[:-1] + [
         "14:-    return commit3",
         "14:+    return commit5",
@@ -88,7 +89,8 @@ def test_diff_context_commit(mock_config, temp_testbed, git_history):
     assert diff_context.files == [rel_path]
 
     file_message = _get_file_message(temp_testbed)
-    annotated_message = diff_context.annotate_file_message(rel_path, file_message)
+    annotations = diff_context.get_diff_annotations(rel_path)
+    annotated_message = annotate_file_message(file_message, annotations)
     expected = file_message[:-1] + [
         "14:-    return a / b",
         "14:+    return commit3",
@@ -104,7 +106,8 @@ def test_diff_context_branch(mock_config, temp_testbed, git_history):
     assert diff_context.files == [rel_path]
 
     file_message = _get_file_message(temp_testbed)
-    annotated_message = diff_context.annotate_file_message(rel_path, file_message)
+    annotations = diff_context.get_diff_annotations(rel_path)
+    annotated_message = annotate_file_message(file_message, annotations)
     expected = file_message[:-1] + [
         "14:-    return commit4",
         "14:+    return commit3",
@@ -120,7 +123,8 @@ def test_diff_context_relative(mock_config, temp_testbed, git_history):
     assert diff_context.files == [rel_path]
 
     file_message = _get_file_message(temp_testbed)
-    annotated_message = diff_context.annotate_file_message(rel_path, file_message)
+    annotations = diff_context.get_diff_annotations(rel_path)
+    annotated_message = annotate_file_message(file_message, annotations)
     expected = file_message[:-1] + [
         "14:-    return a / b",
         "14:+    return commit3",

--- a/tests/parser_tests/block_format_test.py
+++ b/tests/parser_tests/block_format_test.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from textwrap import dedent
 
 from mentat.app import run
@@ -35,7 +36,7 @@ def test_insert(mock_call_llm_api, mock_collect_user_input, mock_setup_api_key):
         @@end""".format(file_name=temp_file_name))])
 
     # Run the system with the temporary file path
-    run([temp_file_name])
+    run([Path(temp_file_name)])
 
     # Check if the temporary file is modified as expected
     with open(temp_file_name, "r") as f:
@@ -153,7 +154,7 @@ def test_create_file(mock_call_llm_api, mock_collect_user_input, mock_setup_api_
         # I created this file
         @@end""".format(file_name=temp_file_name))])
 
-    run(["."])
+    run([Path(".")])
 
     # Check if the temporary file is modified as expected
     with open(temp_file_name, "r") as f:
@@ -189,7 +190,7 @@ def test_delete_file(mock_call_llm_api, mock_collect_user_input, mock_setup_api_
         @@end""".format(file_name=temp_file_name))])
 
     # Run the system with the temporary file path
-    run([temp_file_name])
+    run([Path(temp_file_name)])
 
     # Check if the temporary file is modified as expected
     assert not os.path.exists(temp_file_name)

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from textwrap import dedent
 
 from mentat.app import run
@@ -33,7 +34,7 @@ def test_system(mock_call_llm_api, mock_collect_user_input, mock_setup_api_key):
         @@end""".format(file_name=temp_file_name))])
 
     # Run the system with the temporary file path
-    run([temp_file_name])
+    run([Path(temp_file_name)])
 
     # Check if the temporary file is modified as expected
     with open(temp_file_name, "r") as f:


### PR DESCRIPTION
This commit implements a file-state-manager for the complete git repo - not just the paths included/excluded by user. This gets rid of some redundancy in `diff_context` and `code_maps`, and paves the way for intelligently-selected context, including portions of files, etc.

- The `context_tree` is a graph of `DirectoryNode`s and `FileNode`s which generates and refreshes itself using git/subprocess.
- Nodes track their display status: i.e. whether they're included in the `code_message`, what level of code map, diff info, etc.

I expect there'll be updates per #106, and I still want to make some tweaks, but this is the gist so any and all feedback is much appreciated.