### PR TITLE
Add descriptions and show defaults for all command line parameters

### DIFF
--- a/mentat/config.py
+++ b/mentat/config.py
@@ -35,15 +35,22 @@ class Config:
     # Model specific settings
     model: str = attr.field(
         default="gpt-4-1106-preview",
-        metadata={"auto_completions": list(known_models.keys()),
-                  "description" : "Choose from one of the supported models: " + ",".join(list(known_models.keys()))
-                  },
+        metadata={
+            "auto_completions": list(known_models.keys()),
+            "description": "Choose from one of the supported models: " + ",".join(
+                list(known_models.keys())
+            ),
+        },
     )
     feature_selection_model: str = attr.field(
         default="gpt-4-1106-preview",
-        metadata={"auto_completions": list(known_models.keys()),
-                  "description" : "Choose from one of the supported feature selection models: " + ",".join(list(known_models.keys()))
-                  },
+        metadata={
+            "auto_completions": list(known_models.keys()),
+            "description": (
+                "Choose from one of the supported feature selection models: "
+                + ",".join(list(known_models.keys()))
+            ),
+        },
     )
     embedding_model: str = attr.field(
         default="text-embedding-ada-002",
@@ -51,14 +58,29 @@ class Config:
             "auto_completions": [
                 model.name for model in known_models.values() if model.embedding_model
             ],
-                  "description" : "Choose from one of the supported embedding models: " + ",".join([model.name for model in known_models.values() if model.embedding_model])
+            "description": (
+                "Choose from one of the supported embedding models: "
+                + ",".join(
+                    [
+                        model.name
+                        for model in known_models.values()
+                        if model.embedding_model
+                    ]
+                )
+            ),
         },
     )
     temperature: float = attr.field(
-        default=0.2, converter=float, validator=[validators.le(1), validators.ge(0)],
+        default=0.2,
+        converter=float,
+        validator=[validators.le(1), validators.ge(0)],
         metadata={
-            "description": "Temprature controls the model variability from the context: higher value implies more variability. Teemprature is a floating point number between 0 and 1. "
-        }
+            "description": (
+                "Temprature controls the model variability from the context: higher"
+                " value implies more variability. Teemprature is a floating point"
+                " number between 0 and 1. "
+            )
+        },
     )
 
     maximum_context: int | None = attr.field(

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -78,9 +78,8 @@ class Config:
         validator=[validators.le(1), validators.ge(0)],
         metadata={
             "description": (
-                "The temperature setting used by model. Temprature is a floating point"
-                " number that controls the model variability from the context: higher"
-                " value implies more variability. number between 0 and 1. "
+                "The model's temperature. Temprature is a number between 0 to 1"
+                "  that controls the model variability."
             )
         },
     )

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -35,22 +35,30 @@ class Config:
     # Model specific settings
     model: str = attr.field(
         default="gpt-4-1106-preview",
-        metadata={"auto_completions": list(known_models.keys())},
+        metadata={"auto_completions": list(known_models.keys()),
+                  "description" : "Choose from one of the supported models: " + ",".join(list(known_models.keys()))
+                  },
     )
     feature_selection_model: str = attr.field(
         default="gpt-4-1106-preview",
-        metadata={"auto_completions": list(known_models.keys())},
+        metadata={"auto_completions": list(known_models.keys()),
+                  "description" : "Choose from one of the supported feature selection models: " + ",".join(list(known_models.keys()))
+                  },
     )
     embedding_model: str = attr.field(
         default="text-embedding-ada-002",
         metadata={
             "auto_completions": [
                 model.name for model in known_models.values() if model.embedding_model
-            ]
+            ],
+                  "description" : "Choose from one of the supported embedding models: " + ",".join([model.name for model in known_models.values() if model.embedding_model])
         },
     )
     temperature: float = attr.field(
-        default=0.2, converter=float, validator=[validators.le(1), validators.ge(0)]
+        default=0.2, converter=float, validator=[validators.le(1), validators.ge(0)],
+        metadata={
+            "description": "Temprature controls the model variability from the context: higher value implies more variability. Teemprature is a floating point number between 0 and 1. "
+        }
     )
 
     maximum_context: int | None = attr.field(
@@ -163,6 +171,7 @@ class Config:
             arguments = {
                 "help": field.metadata.get("description", ""),
             }
+            arguments["default"] = field.default
             if "const" in field.metadata:
                 arguments["nargs"] = "?"
                 arguments["const"] = field.metadata["const"]

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -37,7 +37,7 @@ class Config:
         default="gpt-4-1106-preview",
         metadata={
             "auto_completions": list(known_models.keys()),
-            "description": "Choose from one of the supported models: " + ",".join(
+            "description": "Choose from one of the supported models: " + ", ".join(
                 list(known_models.keys())
             ),
         },
@@ -47,8 +47,10 @@ class Config:
         metadata={
             "auto_completions": list(known_models.keys()),
             "description": (
-                "Choose from one of the supported feature selection models: "
-                + ",".join(list(known_models.keys()))
+                "The model used to prune the features before sending to the main model"
+                " for edits. Only used if llm_feature_filter is greater than 0."
+                " Possible models are: "
+                + ", ".join(list(known_models.keys()))
             ),
         },
     )
@@ -60,7 +62,7 @@ class Config:
             ],
             "description": (
                 "Choose from one of the supported embedding models: "
-                + ",".join(
+                + ", ".join(
                     [
                         model.name
                         for model in known_models.values()
@@ -76,9 +78,9 @@ class Config:
         validator=[validators.le(1), validators.ge(0)],
         metadata={
             "description": (
-                "Temprature controls the model variability from the context: higher"
-                " value implies more variability. Teemprature is a floating point"
-                " number between 0 and 1. "
+                "The temperature setting used by model. Temprature is a floating point"
+                " number that controls the model variability from the context: higher"
+                " value implies more variability. number between 0 and 1. "
             )
         },
     )

--- a/mentat/config.py
+++ b/mentat/config.py
@@ -61,7 +61,7 @@ class Config:
                 model.name for model in known_models.values() if model.embedding_model
             ],
             "description": (
-                "Choose from one of the supported embedding models: "
+                "The model used to create embeddings for auto context: "
                 + ", ".join(
                     [
                         model.name
@@ -78,7 +78,7 @@ class Config:
         validator=[validators.le(1), validators.ge(0)],
         metadata={
             "description": (
-                "The model's temperature. Temprature is a number between 0 to 1"
+                "The model's temperature. Temperature is a number between 0 to 1"
                 "  that controls the model variability."
             )
         },

--- a/mentat/terminal/client.py
+++ b/mentat/terminal/client.py
@@ -237,6 +237,7 @@ def get_parser():
         default=None,
         help="A git tree-ish to diff against the latest common ancestor of",
     )
+    # TODO Change the default to show "current working directpry" and fix when running - otherwise documentation is wrong.
     parser.add_argument(
         "--cwd", default=Path.cwd(), help="The current working directory"
     )

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -296,7 +296,7 @@ async def test_config_command(mock_call_llm_api):
     await command.apply("test")
     assert stream.messages[-1].data == "Unrecognized config option: test"
     await command.apply("model")
-    assert stream.messages[-1].data.startswith("model: ")
+    assert stream.messages[-1].data.startswith(("model: ","Description: "))
     await command.apply("model", "test")
     assert stream.messages[-1].data == "model set to test"
     assert config.model == "test"

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -296,7 +296,7 @@ async def test_config_command(mock_call_llm_api):
     await command.apply("test")
     assert stream.messages[-1].data == "Unrecognized config option: test"
     await command.apply("model")
-    assert stream.messages[-1].data.startswith(("model: ","Description: "))
+    assert stream.messages[-1].data.startswith(("model: ", "Description: "))
     await command.apply("model", "test")
     assert stream.messages[-1].data == "model set to test"
     assert config.model == "test"

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -38,7 +38,7 @@ async def test_config_creation():
     assert args.model == "model"
     assert args.temperature == 0.2
     assert args.maximum_context == "1"
-    assert args.parser is None
+    assert args.parser == "block"
     assert args.auto_context_tokens == 2000
 
     with open(config_file_name, "w") as project_config_file:


### PR DESCRIPTION
Not all the commandline options had descriptions. 
Also the defaults were not showing up in the documentation - fix that.